### PR TITLE
fix: handle empty messages in login error and warn about special characters

### DIFF
--- a/custom_components/rohlikcz/rohlik_api.py
+++ b/custom_components/rohlikcz/rohlik_api.py
@@ -128,10 +128,22 @@ class RohlikCZAPI:
             login_response: dict = login_response.json()
 
             if login_response["status"] != 200:
+                messages = login_response.get("messages", [])
+                error_detail = messages[0]["content"] if messages else None
+                _LOGGER.error(f"Login failed with status {login_response['status']}. Response: {mask_data(login_response)}")
                 if login_response["status"] == 401:
-                    raise InvalidCredentialsError(login_response["messages"][0]["content"])
+                    if error_detail:
+                        raise InvalidCredentialsError(error_detail)
+                    raise InvalidCredentialsError(
+                        "Login failed. Please check your credentials. "
+                        "If your password contains special characters (e.g. `, $, +, etc.), "
+                        "try changing it to use only standard characters — "
+                        "Rohlik.cz may not handle them correctly."
+                    )
                 else:
-                    raise RohlikczError(f"Unknown error occurred during login: {login_response["messages"][0]["content"]}")
+                    if not error_detail:
+                        error_detail = f"status code {login_response['status']}"
+                    raise RohlikczError(f"Unknown error occurred during login: {error_detail}")
 
             if not self._user_id:
                 self._user_id = login_response.get("data", {}).get("user", {}).get("id", None)

--- a/readme.md
+++ b/readme.md
@@ -36,9 +36,12 @@ From the Home Assistant front page go to **Configuration** and then select **Int
 Use the "plus" button in the bottom right to add a new integration called **Rohlik.cz**.
 
 Fill in:
- 
+
 - Email (your Rohlik.cz account email)
 - Password (your Rohlik.cz account password)
+
+> [!NOTE]
+> If your password contains special characters (e.g. `` ` ``, `$`, `+`), login may fail due to a Rohlik.cz server-side limitation. If you experience login issues, try changing your Rohlik.cz password to use only standard alphanumeric characters and common symbols.
 
 The integration will connect to your Rohlik.cz account and set up the entities.
 


### PR DESCRIPTION
## Summary

Fixes #63

- When login fails and the API returns an empty `messages` array, the integration crashed with `IndexError: list index out of range`. This is now handled gracefully.
- When login fails with 401 and no error message from the server, the user now gets a helpful hint: *"If your password contains special characters (e.g. `, $, +, etc.), try changing it to use only standard characters — Rohlik.cz may not handle them correctly."*
- Added a note to the README under Configuration warning about this known server-side limitation.

## Root cause

Rohlik.cz server doesn't properly handle certain special characters in passwords (e.g. backtick `` ` ``). When such a password is sent, the server returns a 401 response with an empty `messages` array instead of the usual error message. The original code assumed `messages` would always have at least one element.

## Test plan

- [x] Verified fix handles empty `messages` array without crashing
- [x] Verified helpful error message is shown for 401 with empty messages
- [x] Verified normal 401 flow (wrong password, non-empty messages) still works as before
- [x] Verified non-401 errors with empty messages also handled correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)