### PR TITLE
feat: add refresh_slots action for lightweight express-slot polling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,3 +162,6 @@ cython_debug/
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
 
+# macOS
+.DS_Store
+

--- a/automations/refresh_slots.yaml
+++ b/automations/refresh_slots.yaml
@@ -1,0 +1,51 @@
+# Example: quickly watch for express availability using the lightweight
+# rohlikcz.refresh_slots action.
+#
+# The integration refreshes ALL data on a 10-minute cycle. rohlikcz.refresh_slots
+# fetches ONLY the delivery timeslots (a single request, reusing a logged-in
+# session), so it is cheap enough to poll every ~15s while you are actually
+# waiting for an express slot to open.
+#
+# This automation is "armed" by an input_boolean so it only polls on demand
+# instead of hammering the server 24/7. Create the helper first under
+# Settings > Devices & Services > Helpers > Toggle, e.g.
+#   input_boolean.rohlik_express_alert_active
+# To start watching, simply turn that helper on.
+alias: Rohlik Express - Watch and Notify
+description: >-
+  While armed, repeatedly refresh only the Rohlik delivery slots until express
+  becomes available, then notify and disarm.
+triggers:
+  - entity_id: input_boolean.rohlik_express_alert_active # Your "arm" helper
+    to: "on"
+    trigger: state
+actions:
+  - repeat:
+      while:
+        # Keep polling while armed AND express is not yet available
+        - condition: state
+          entity_id: input_boolean.rohlik_express_alert_active
+          state: "on"
+        - condition: state
+          entity_id: binary_sensor.xxxxxxxx_express_available # Replace with your express binary sensor
+          state: "off"
+      sequence:
+        - action: rohlikcz.refresh_slots # Lightweight timeslot-only refresh
+          data:
+            config_entry_id: XXXXXXXXXXXXXXXX # Replace with your Rohlik.cz config entry ID
+        - delay:
+            seconds: 15 # Poll interval; lower for snappier, higher for gentler
+  # Express opened (or you disarmed). Notify only if it actually became available.
+  - if:
+      - condition: state
+        entity_id: binary_sensor.xxxxxxxx_express_available # Replace with your express binary sensor
+        state: "on"
+    then:
+      - action: notify.notify # Replace with your notify service or script
+        data:
+          title: Rohlik Express is available!
+          message: You can now place your express order.
+  - action: input_boolean.turn_off # Disarm so polling stops
+    target:
+      entity_id: input_boolean.rohlik_express_alert_active
+mode: single

--- a/custom_components/rohlikcz/__init__.py
+++ b/custom_components/rohlikcz/__init__.py
@@ -91,6 +91,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
     if unload_ok:
-        hass.data[DOMAIN].pop(entry.entry_id)
+        rohlik_hub = hass.data[DOMAIN].pop(entry.entry_id)
+        await rohlik_hub.async_close()
 
     return unload_ok

--- a/custom_components/rohlikcz/const.py
+++ b/custom_components/rohlikcz/const.py
@@ -57,6 +57,7 @@ SERVICE_GET_CART_CONTENT = "get_cart_content"
 SERVICE_SEARCH_AND_ADD_PRODUCT = "search_and_add_to_cart"
 SERVICE_UPDATE_DATA = "update_data"
 SERVICE_FETCH_ORDER_HISTORY = "fetch_order_history"
+SERVICE_REFRESH_SLOTS = "refresh_slots"
 
 """ Analytics options """
 CONF_ANALYTICS = "analytics"

--- a/custom_components/rohlikcz/errors.py
+++ b/custom_components/rohlikcz/errors.py
@@ -18,4 +18,4 @@ class AddressNotSetError(RohlikczError):
 
 
 class APIRequestFailedError(RohlikczError):
-    """ No delivery address set in user account. """
+    """ API request to rohlik.cz failed. """

--- a/custom_components/rohlikcz/hub.py
+++ b/custom_components/rohlikcz/hub.py
@@ -420,6 +420,15 @@ class RohlikAccount:
 
         await self.publish_updates()
 
+    async def refresh_slots(self) -> None:
+        """Refresh only the delivery timeslot data (cheap express-availability check).
+
+        Unlike async_update, this merges into self.data instead of replacing it, so the
+        other sensors keep their existing values.
+        """
+        self.data["next_delivery_slot"] = await self._rohlik_api.get_timeslots()
+        await self.publish_updates()
+
     async def _auto_enrich_new_orders(self, new_count: int) -> None:
         """Auto-enrich recently added orders in the background."""
         enriched = False
@@ -618,3 +627,7 @@ class RohlikAccount:
         result = await self._rohlik_api.delete_from_cart(order_field_id)
         await self.async_update()  # Refresh data after deletion
         return result
+
+    async def async_close(self) -> None:
+        """Release resources held by the account (e.g. the reusable API session)."""
+        await self._rohlik_api.close_session()

--- a/custom_components/rohlikcz/hub.py
+++ b/custom_components/rohlikcz/hub.py
@@ -5,7 +5,7 @@ import logging
 import os
 from collections.abc import Callable
 from datetime import datetime
-from typing import Any, cast, List, Optional, Dict
+from typing import Any, Optional, Dict
 from zoneinfo import ZoneInfo
 
 from homeassistant.core import HomeAssistant

--- a/custom_components/rohlikcz/rohlik_api.py
+++ b/custom_components/rohlikcz/rohlik_api.py
@@ -81,6 +81,8 @@ class RohlikCZAPI:
         self._user_id = None
         self._address_id = None
         self.endpoints = {}
+        self._session = None
+        self._session_lock = asyncio.Lock()  # serializes access to the reused session
 
     def _run_in_executor(self, func, *args, **kwargs):
         """
@@ -230,6 +232,70 @@ class RohlikCZAPI:
             # Step 3: Close the session
             await self.logout(session)
             await self._run_in_executor(session.close)
+
+    async def _ensure_session(self):
+        """
+        Return a persistent, logged-in session, creating and authenticating it on first use.
+
+        Unlike the other methods in this client, the session is kept open and reused across
+        calls so that lightweight polling (see get_timeslots) does not require a fresh
+        login/logout round-trip every time.
+
+        Returns:
+            requests.Session: An authenticated session.
+        """
+        if self._session is None:
+            self._session = requests.Session()
+            await self.login(self._session)
+        return self._session
+
+    async def get_timeslots(self):
+        """
+        Fetch only the delivery timeslot data, reusing a persistent logged-in session.
+
+        This is a lightweight alternative to get_data() for checking express slot
+        availability. It performs a single GET against the timeslot endpoint and only
+        re-authenticates if the persistent session has expired (HTTP 401).
+
+        Returns:
+            dict | None: The parsed timeslot JSON, or None if no delivery address is
+                available or the request fails.
+        """
+        async with self._session_lock:
+            await self._ensure_session()
+
+            if not self._address_id:
+                return None
+
+            path = f"/services/frontend-service/timeslots-api/0?userId={self._user_id}&addressId={self._address_id}&reasonableDeliveryTime=true"
+            url = f"{BASE_URL}{path}"
+
+            # A reused session can fail transiently: the login may have expired
+            # (HTTP 401), or a keep-alive connection left idle between polls may
+            # have been closed by the server (connection reset). Retry once — on
+            # 401 with a fresh login, otherwise on a fresh connection.
+            for attempt in range(2):
+                try:
+                    session = await self._ensure_session()
+                    response = await self._run_in_executor(session.get, url)
+                    if response.status_code == 401:
+                        self._session = None  # expired login: re-auth on retry
+                        if attempt == 0:
+                            continue
+                    response.raise_for_status()
+                    return response.json()
+                except RequestException as err:
+                    if attempt == 0:
+                        continue  # transient (e.g. stale connection): retry once
+                    _LOGGER.error(f"Error fetching timeslots: {err}")
+                    return None
+
+    async def close_session(self) -> None:
+        """Close the persistent session if one is open (called on unload)."""
+        async with self._session_lock:
+            if self._session is not None:
+                await self._run_in_executor(self._session.close)
+                self._session = None
 
     async def get_delivered_orders_page(self, session, offset: int = 0, limit: int = 50) -> list:
         """Fetch a page of delivered orders using an existing authenticated session."""

--- a/custom_components/rohlikcz/rohlik_api.py
+++ b/custom_components/rohlikcz/rohlik_api.py
@@ -463,9 +463,6 @@ class RohlikCZAPI:
                 "canCorrect": True
             }
 
-            # Login to account to return user-specific data
-            await self.login(session)
-
             # Perform API request
             search_response = await self._run_in_executor(
                 session.get,

--- a/custom_components/rohlikcz/sensor.py
+++ b/custom_components/rohlikcz/sensor.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 import logging
 import re
-import datetime
 
 from collections.abc import Mapping
 from datetime import timedelta, datetime, time

--- a/custom_components/rohlikcz/services.py
+++ b/custom_components/rohlikcz/services.py
@@ -10,7 +10,8 @@ from homeassistant.helpers import config_validation as cv
 
 from .const import DOMAIN, ATTR_CONFIG_ENTRY_ID, ATTR_PRODUCT_ID, ATTR_QUANTITY, ATTR_PRODUCT_NAME, \
     ATTR_SHOPPING_LIST_ID, ATTR_LIMIT, ATTR_FAVOURITE_ONLY, SERVICE_ADD_TO_CART, SERVICE_SEARCH_PRODUCT, SERVICE_GET_SHOPPING_LIST, \
-    SERVICE_GET_CART_CONTENT, SERVICE_SEARCH_AND_ADD_PRODUCT, SERVICE_UPDATE_DATA, SERVICE_FETCH_ORDER_HISTORY
+    SERVICE_GET_CART_CONTENT, SERVICE_SEARCH_AND_ADD_PRODUCT, SERVICE_UPDATE_DATA, SERVICE_FETCH_ORDER_HISTORY, \
+    SERVICE_REFRESH_SLOTS
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -130,6 +131,20 @@ def register_services(hass: HomeAssistant) -> None:
         except Exception as err:
             raise HomeAssistantError(f"Failed to update data: {err}")
 
+    async def async_refresh_slots(call: ServiceCall) -> None:
+        """Refresh only the delivery timeslot data (lightweight express availability check)."""
+        config_entry_id = call.data[ATTR_CONFIG_ENTRY_ID]
+
+        if config_entry_id not in hass.data[DOMAIN]:
+            raise HomeAssistantError(f"Config entry {config_entry_id} not found")
+
+        account = hass.data[DOMAIN][config_entry_id]
+        try:
+            await account.refresh_slots()
+
+        except Exception as err:
+            raise HomeAssistantError(f"Failed to refresh slots: {err}")
+
 
     async def async_fetch_order_history(call: ServiceCall) -> None:
         """Fetch complete order history from Rohlik."""
@@ -225,6 +240,16 @@ def register_services(hass: HomeAssistant) -> None:
         DOMAIN,
         SERVICE_UPDATE_DATA,
         async_update_data,
+        schema=vol.Schema({
+            vol.Required(ATTR_CONFIG_ENTRY_ID): cv.string
+        }),
+        supports_response=SupportsResponse.NONE
+    )
+
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_REFRESH_SLOTS,
+        async_refresh_slots,
         schema=vol.Schema({
             vol.Required(ATTR_CONFIG_ENTRY_ID): cv.string
         }),

--- a/custom_components/rohlikcz/services.py
+++ b/custom_components/rohlikcz/services.py
@@ -114,7 +114,7 @@ def register_services(hass: HomeAssistant) -> None:
             return result
         except Exception as err:
             _LOGGER.error(f"Failed to get cart content: {err}")
-            raise HomeAssistantError(f"Failed to get get cart content: {err}")
+            raise HomeAssistantError(f"Failed to get cart content: {err}")
 
     async def async_update_data(call: ServiceCall) -> None:
         """Updates integration data."""

--- a/custom_components/rohlikcz/services.yaml
+++ b/custom_components/rohlikcz/services.yaml
@@ -108,6 +108,18 @@ update_data:
         config_entry:
           integration: rohlikcz
 
+refresh_slots:
+  name: Refresh delivery slots
+  description: Fetch only the delivery timeslot data to quickly refresh express availability without a full data update. Cheap enough to poll frequently.
+  fields:
+    config_entry_id:
+      name: Account
+      description: The Rohlik account to use
+      required: true
+      selector:
+        config_entry:
+          integration: rohlikcz
+
 search_and_add_to_cart:
   name: Search and add to cart
   description: Search for a product and add to a shopping cart

--- a/custom_components/rohlikcz/todo.py
+++ b/custom_components/rohlikcz/todo.py
@@ -112,7 +112,7 @@ class RohlikCartTodo(TodoListEntity):
         result = await self._rohlik_hub.search_and_add(product_name, quantity)
 
         if not result or not result.get("success", False):
-            _LOGGER.error("Error with adding product to")
+            _LOGGER.error("Failed to add product to cart: %s", product_name)
             raise ServiceValidationError(f"Product not found: {product_name}")
 
 
@@ -122,7 +122,7 @@ class RohlikCartTodo(TodoListEntity):
             try:
                 # Call the new delete_from_cart method with the cart_item_id
                 await self._rohlik_hub.delete_from_cart(uid)
-                _LOGGER.error(f"Deleted item: {uid}")
+                _LOGGER.debug(f"Deleted item: {uid}")
             except Exception as err:
                 _LOGGER.error("Error deleting item %s: %s", uid, err)
 

--- a/tests/test_order_store.py
+++ b/tests/test_order_store.py
@@ -59,39 +59,36 @@ def test_order_store():
 
         # Test: yearly totals
         yearly_2026 = sum(o["amount"] for o in data["orders"].values() if o["date"].startswith("2026"))
-    assert yearly_2026 == 1700.0, f"Expected 2026 total 1700.0, got {yearly_2026}"
+        assert yearly_2026 == 1700.0, f"Expected 2026 total 1700.0, got {yearly_2026}"
 
-    yearly_2025 = sum(o["amount"] for o in data["orders"].values() if o["date"].startswith("2025"))
-    assert yearly_2025 == 800.0, f"Expected 2025 total 800.0, got {yearly_2025}"
+        yearly_2025 = sum(o["amount"] for o in data["orders"].values() if o["date"].startswith("2025"))
+        assert yearly_2025 == 800.0, f"Expected 2025 total 800.0, got {yearly_2025}"
 
-    # Test: alltime total
-    alltime = sum(o["amount"] for o in data["orders"].values())
-    assert alltime == 2500.0, f"Expected alltime 2500.0, got {alltime}"
+        # Test: alltime total
+        alltime = sum(o["amount"] for o in data["orders"].values())
+        assert alltime == 2500.0, f"Expected alltime 2500.0, got {alltime}"
 
-    # Test: first order date
-    dates = [o["date"] for o in data["orders"].values() if o["date"]]
-    first = min(dates)
-    assert first == "2025-12-01", f"Expected first date 2025-12-01, got {first}"
+        # Test: first order date
+        dates = [o["date"] for o in data["orders"].values() if o["date"]]
+        first = min(dates)
+        assert first == "2025-12-01", f"Expected first date 2025-12-01, got {first}"
 
-    # Test: save and reload persistence
-    with open(store_path, "w") as f:
-        json.dump(data, f)
-    with open(store_path, "r") as f:
-        reloaded = json.load(f)
-    assert len(reloaded["orders"]) == 3, "Persistence failed"
+        # Test: save and reload persistence
+        with open(store_path, "w") as f:
+            json.dump(data, f)
+        with open(store_path, "r") as f:
+            reloaded = json.load(f)
+        assert len(reloaded["orders"]) == 3, "Persistence failed"
 
-    # Test: processing same orders again adds nothing (deduplication)
-    second_count = 0
-    for order in orders[:3]:
-        order_id = str(order.get("id", ""))
-        if not order_id or order_id in data["orders"]:
-            continue
-        second_count += 1
-    assert second_count == 0, f"Dedup failed: got {second_count} new on re-process"
+        # Test: processing same orders again adds nothing (deduplication)
+        second_count = 0
+        for order in orders[:3]:
+            order_id = str(order.get("id", ""))
+            if not order_id or order_id in data["orders"]:
+                continue
+            second_count += 1
+        assert second_count == 0, f"Dedup failed: got {second_count} new on re-process"
 
-    # Cleanup
-    os.remove(store_path)
-    os.rmdir(tmpdir)
     print("All tests passed!")
 
 


### PR DESCRIPTION
## Summary

Express availability (the `IsExpressAvailable` binary sensor) only updates on the 600s `SCAN_INTERVAL`, so it can be up to ~10 minutes stale.

The concrete motivation: in my Home Assistant setup I have a "notify when express available" toggle that pushes a notification to my phone the moment express becomes available, so I can grab a slot. Express slots go fast, and a refresh cadence of up to 10 minutes was far too slow; the notification often arrived after the slots were already gone.

The existing `update_data` service can force a refresh, but it does a full login, ~10 endpoint GETs, the cart, and a logout (about 12 requests), so polling it every few seconds to catch express in time would hammer the server.

This adds a dedicated `rohlikcz.refresh_slots` action that fetches only the timeslot endpoint, cheap enough to poll every ~15s (in my case only while the alert is armed) so the notification fires within seconds instead of minutes. The included example automation shows exactly this pattern.

## What changed

Feature:
- `RohlikCZAPI.get_timeslots()`: a single GET to the timeslots-api endpoint (the same URL `get_data` already builds for `next_delivery_slot`).
- A reused, logged-in `requests.Session`, so a slot check is one request instead of login + GET + logout. It re-authenticates only on HTTP 401 and retries once on a transient connection reset (a stale keep-alive connection closed by the server between polls). Access is serialized with an `asyncio.Lock`, and the session is closed on unload.
- `RohlikAccount.refresh_slots()`: merges the result into `self.data["next_delivery_slot"]` (it does not replace `self.data`) and publishes updates, so the express sensor refreshes while every other sensor keeps its value.
- Service registration (`config_entry_id` required, `SupportsResponse.NONE`), a `services.yaml` entry, and an example automation in `automations/refresh_slots.yaml`.

`get_data()` is left unchanged and stays stateless; only `refresh_slots` uses the persistent session. No DataUpdateCoordinator refactor; this is intentionally minimal and follows existing patterns.

Small fixes found along the way (kept in a separate commit):
- `tests/test_order_store.py`: asserts were indented outside the `TemporaryDirectory` block, so the test raised `FileNotFoundError`; re-indented and dropped the redundant manual cleanup.
- `rohlik_api.py`: `search_product` called `login()` twice.
- `services.py`: "Failed to get get cart content" doubled-word typo.
- `hub.py`: removed unused `cast` and `List` imports.
- `sensor.py`: removed a dead, shadowed `import datetime`.
- `errors.py`: `APIRequestFailedError` docstring was copied verbatim from `AddressNotSetError`.
- `todo.py`: completed a truncated add-to-cart error log and lowered a successful-delete log from error to debug.

## Test plan

- Integration loads with no errors and all entities populate (confirms the removed imports were unused).
- `rohlikcz.refresh_slots` appears in Developer Tools and runs with no error.
- With `urllib3.connectionpool` debug logging, `refresh_slots` performs a single GET to `timeslots-api`, versus `update_data` doing the full login + endpoints + logout.
- After `refresh_slots`, the express binary sensor reflects current availability while cart/premium/other sensors keep their values (confirms the data merge, not a replace).
- Reloaded the integration with no leaked-session errors (confirms the session is closed on unload).
- Observed a transient "Connection reset by peer" from a stale keep-alive connection; the added one-shot retry recovers without surfacing it.