### PR TITLE
Rewrite API client to use aiohttp instead of requests-in-executor

### DIFF
--- a/custom_components/rohlikcz/rohlik_api.py
+++ b/custom_components/rohlikcz/rohlik_api.py
@@ -383,7 +383,10 @@ class RohlikCZAPI:
             _LOGGER.error(f"Error during full order history fetch: {err}")
             return all_orders
         finally:
-            await self.logout(session)
+            try:
+                await self.logout(session)
+            except Exception:
+                pass
             await session.close()
 
     async def add_to_cart(self, product_list: list[dict]) -> dict:
@@ -398,6 +401,8 @@ class RohlikCZAPI:
 
         session = self._new_session()
         try:
+            # A login network failure surfaces as APIRequestFailedError; per-product
+            # failures below are caught individually.
             await self.login(session)
 
             search_url = "/services/frontend-service/v2/cart"
@@ -420,9 +425,6 @@ class RohlikCZAPI:
 
             return {"added_products": added_products}
 
-        except _NETWORK_ERRORS as err:
-            _LOGGER.error(f"Request failed: {err}")
-            raise ValueError("Request failed")
         finally:
             try:
                 await self.logout(session)

--- a/custom_components/rohlikcz/rohlik_api.py
+++ b/custom_components/rohlikcz/rohlik_api.py
@@ -379,10 +379,10 @@ class RohlikCZAPI:
 
             return all_orders
 
-        except _NETWORK_ERRORS as err:
-            _LOGGER.error(f"Error during full order history fetch: {err}")
-            return all_orders
         finally:
+            # Per-page network errors are handled in get_delivered_orders_page
+            # (which returns [] and ends pagination), so no network error can
+            # reach here; a login failure propagates to the caller.
             try:
                 await self.logout(session)
             except Exception:
@@ -547,11 +547,14 @@ class RohlikCZAPI:
         """
 
         cart_url = "/services/frontend-service/v2/cart"
+        own_session = not logged_in
 
-        if not logged_in:
+        if own_session:
             session = self._new_session()
-            await self.login(session)
         try:
+            # Login inside the try so the session is still closed if it fails.
+            if own_session:
+                await self.login(session)
             async with session.get(f"{BASE_URL}{cart_url}") as response:
                 response.raise_for_status()
                 cart_content = await response.json(content_type=None)
@@ -560,7 +563,7 @@ class RohlikCZAPI:
             _LOGGER.error(f"Request failed: {err}")
             raise ValueError("Request failed")
         finally:
-            if not logged_in:
+            if own_session:
                 try:
                     await self.logout(session)
                 except Exception:

--- a/custom_components/rohlikcz/rohlik_api.py
+++ b/custom_components/rohlikcz/rohlik_api.py
@@ -3,6 +3,11 @@ RohlikCZ API Client
 
 This module provides an asynchronous API client for interacting with Rohlik.cz, a Czech online grocery delivery service. It allows logging in, retrieving account data, searching products, managing shopping carts, and accessing shopping lists.
 
+Networking uses aiohttp directly (no blocking calls in the event loop). Each
+public operation uses its own ClientSession with an isolated cookie jar, so the
+login/logout cycle of one operation never interferes with another running
+concurrently (e.g. a background enrichment overlapping a regular refresh).
+
 Example:
     from rohlik_api import RohlikCZAPI
 
@@ -12,19 +17,22 @@ Example:
         print(data)
 """
 
-import logging
-import requests
-
-from requests import Response
-from requests.exceptions import RequestException
-from typing import TypedDict, Dict
-from .errors import InvalidCredentialsError, RohlikczError, APIRequestFailedError
 import asyncio
-import functools
+import json
+import logging
+
+import aiohttp
+
+from typing import TypedDict, Dict
+from .const import HTTP_TIMEOUT
+from .errors import InvalidCredentialsError, RohlikczError, APIRequestFailedError
 
 _LOGGER = logging.getLogger(__name__)
 
 BASE_URL = "https://www.rohlik.cz"
+
+# Errors raised by aiohttp for connection/timeout problems.
+_NETWORK_ERRORS = (aiohttp.ClientError, asyncio.TimeoutError)
 
 
 def mask_data(input_dict):
@@ -82,84 +90,64 @@ class RohlikCZAPI:
         self._address_id = None
         self.endpoints = {}
 
-    def _run_in_executor(self, func, *args, **kwargs):
-        """
-        Run blocking requests calls in a thread executor to maintain async compatibility.
+    def _new_session(self) -> aiohttp.ClientSession:
+        """Create a fresh client session with an isolated cookie jar."""
+        return aiohttp.ClientSession(timeout=HTTP_TIMEOUT)
 
-        This helper method ensures that blocking HTTP calls don't block the asyncio event loop
-        by running them in a separate thread executor.
-
-        Args:
-            func (callable): The function to execute (typically a requests method)
-            *args: Positional arguments to pass to the function
-            **kwargs: Keyword arguments to pass to the function
-
-        Returns:
-            asyncio.Future: A future representing the execution of the function
-        """
-        return asyncio.get_event_loop().run_in_executor(
-            None, functools.partial(func, *args, **kwargs)
-        )
-
-    async def login(self, session):
+    async def login(self, session: aiohttp.ClientSession):
         """
         Authenticate with the Rohlik.cz service.
 
         Args:
-            session (requests.Session): An active requests session to use for authentication
+            session (aiohttp.ClientSession): An active session to use for authentication
 
         Returns:
             dict: The JSON response containing authentication data and user information
 
         Raises:
-            requests.exceptions.RequestException: If the login request fails
+            APIRequestFailedError: If the login request fails at the network level
+            InvalidCredentialsError / RohlikczError: If the API rejects the login
         """
 
         login_data = {"email": self._user, "password": self._pass, "name": ""}
         login_url = f"{BASE_URL}/services/frontend-service/login"
 
         try:
-            login_response: Response = await self._run_in_executor(
-                session.post,
-                login_url,
-                json=login_data
-            )
-
-            login_response: dict = login_response.json()
-
-            if login_response["status"] != 200:
-                # The Rohlik API sometimes returns an empty "messages" array on
-                # failure, so extract the error message defensively to avoid an
-                # IndexError masking the real status code.
-                messages = login_response.get("messages") or []
-                fallback_detail = f"status code {login_response['status']}, no message provided"
-                if messages and isinstance(messages[0], dict):
-                    # Fall back when content is missing or an empty string.
-                    error_detail = messages[0].get("content") or fallback_detail
-                else:
-                    error_detail = fallback_detail
-
-                if login_response["status"] == 401:
-                    raise InvalidCredentialsError(error_detail)
-                else:
-                    _LOGGER.error(f"Login failed. Status: {login_response['status']}, Full response: {mask_data(login_response)}")
-                    raise RohlikczError(f"Unknown error occurred during login: {error_detail}")
-
-            if not self._user_id:
-                self._user_id = login_response.get("data", {}).get("user", {}).get("id", None)
-
-            if not self._address_id:
-                try:
-                    self._address_id = login_response.get("data", {}).get("address", {}).get("id", None)
-                except AttributeError:
-                    _LOGGER.error(f"Address cannot be retrieved from login data. No delivery time sensors will be added. Login response: {mask_data(login_response)}")
-
-            return login_response
-
-        except RequestException as err:
+            async with session.post(login_url, json=login_data) as response:
+                login_response: dict = await response.json(content_type=None)
+        except _NETWORK_ERRORS as err:
             raise APIRequestFailedError(f"Cannot connect to website! Check your internet connection and try again: {err}")
 
-    async def logout(self, session) -> None:
+        if login_response["status"] != 200:
+            # The Rohlik API sometimes returns an empty "messages" array on
+            # failure, so extract the error message defensively to avoid an
+            # IndexError masking the real status code.
+            messages = login_response.get("messages") or []
+            fallback_detail = f"status code {login_response['status']}, no message provided"
+            if messages and isinstance(messages[0], dict):
+                # Fall back when content is missing or an empty string.
+                error_detail = messages[0].get("content") or fallback_detail
+            else:
+                error_detail = fallback_detail
+
+            if login_response["status"] == 401:
+                raise InvalidCredentialsError(error_detail)
+            else:
+                _LOGGER.error(f"Login failed. Status: {login_response['status']}, Full response: {mask_data(login_response)}")
+                raise RohlikczError(f"Unknown error occurred during login: {error_detail}")
+
+        if not self._user_id:
+            self._user_id = login_response.get("data", {}).get("user", {}).get("id", None)
+
+        if not self._address_id:
+            try:
+                self._address_id = login_response.get("data", {}).get("address", {}).get("id", None)
+            except AttributeError:
+                _LOGGER.error(f"Address cannot be retrieved from login data. No delivery time sensors will be added. Login response: {mask_data(login_response)}")
+
+        return login_response
+
+    async def logout(self, session: aiohttp.ClientSession) -> None:
         """
         Log out from the Rohlik.cz service.
         :param session:
@@ -168,19 +156,13 @@ class RohlikCZAPI:
         logout_url = f"{BASE_URL}/services/frontend-service/logout"
 
         try:
-            logout_response: Response = await self._run_in_executor(
-                session.post,
-                logout_url
-            )
-
-            logout_response: dict = logout_response.json()
-
-            if logout_response["status"] != 200:
-                raise RohlikczError(f"Unknown error occurred during logout: {logout_response}")
-
-
-        except RequestException as err:
+            async with session.post(logout_url) as response:
+                logout_response: dict = await response.json(content_type=None)
+        except _NETWORK_ERRORS as err:
             raise APIRequestFailedError(f"Cannot connect to website! Check your internet connection and try again: {err}")
+
+        if logout_response["status"] != 200:
+            raise RohlikczError(f"Unknown error occurred during logout: {logout_response}")
 
     async def get_data(self):
         """
@@ -190,7 +172,7 @@ class RohlikCZAPI:
             dict: A dictionary containing all data from various Rohlik endpoints,
                  including login information, delivery details, cart contents,
         """
-        session = requests.Session()
+        session = self._new_session()
         result: dict = {}
         self.endpoints = {
             "delivery": "/services/frontend-service/first-delivery?reasonableDeliveryTime=true",
@@ -205,9 +187,11 @@ class RohlikCZAPI:
             "delivered_orders": "/api/v3/orders/delivered?offset=0&limit=50"
         }
 
-        result["login"] = await self.login(session)
-
         try:
+            # Login first; if this fails the error propagates (logout in the
+            # finally is best-effort and never masks it).
+            result["login"] = await self.login(session)
+
             # Step 2: Get data from all other endpoints
             for endpoint, path in self.endpoints.items():
 
@@ -220,85 +204,85 @@ class RohlikCZAPI:
 
                 try:
                     url = f"{BASE_URL}{path}"
-                    response = await self._run_in_executor(session.get, url)
-                    response.raise_for_status()
-                    result[endpoint] = response.json()
-                except RequestException as err:
+                    async with session.get(url) as response:
+                        response.raise_for_status()
+                        result[endpoint] = await response.json(content_type=None)
+                except Exception as err:
                     _LOGGER.error(f"Error fetching {endpoint}: {err}")
                     result[endpoint] = None
 
             try:
                 result["cart"] = await self.get_cart_content(logged_in=True, session=session)
-
-            except RequestException as err:
+            except Exception as err:
                 _LOGGER.error(f"Error fetching cart: {err}")
                 result["cart"] = None
 
             return result
 
-        except RequestException as err:
-            raise APIRequestFailedError(f"Cannot connect to website! Check your internet connection and try again: {err}")
         finally:
-            # Step 3: Close the session
-            await self.logout(session)
-            await self._run_in_executor(session.close)
+            # Step 3: Log out (best-effort) and always close the session.
+            try:
+                await self.logout(session)
+            except Exception:
+                pass
+            await session.close()
 
-    async def get_delivered_orders_page(self, session, offset: int = 0, limit: int = 50) -> list:
+    async def get_delivered_orders_page(self, session: aiohttp.ClientSession, offset: int = 0, limit: int = 50) -> list:
         """Fetch a page of delivered orders using an existing authenticated session."""
         url = f"{BASE_URL}/api/v3/orders/delivered?offset={offset}&limit={limit}"
         try:
-            response = await self._run_in_executor(session.get, url)
-            response.raise_for_status()
-            return response.json()
-        except RequestException as err:
+            async with session.get(url) as response:
+                response.raise_for_status()
+                return await response.json(content_type=None)
+        except _NETWORK_ERRORS as err:
             _LOGGER.error(f"Error fetching delivered orders page (offset={offset}): {err}")
             return []
 
-    async def get_order_detail(self, session, order_id: str) -> dict | None:
+    async def get_order_detail(self, session: aiohttp.ClientSession, order_id: str) -> dict | None:
         """Fetch detailed order info including items for a single order."""
         url = f"{BASE_URL}/api/v3/orders/{order_id}"
         try:
-            response = await self._run_in_executor(session.get, url)
-            response.raise_for_status()
-            return response.json()
-        except RequestException as err:
+            async with session.get(url) as response:
+                response.raise_for_status()
+                return await response.json(content_type=None)
+        except _NETWORK_ERRORS as err:
             _LOGGER.error(f"Error fetching order detail for {order_id}: {err}")
             return None
 
-    async def get_product_categories(self, session, product_id: int) -> list | None:
+    async def get_product_categories(self, session: aiohttp.ClientSession, product_id: int) -> list | None:
         """Fetch category hierarchy for a product. Returns None for 404 (discontinued)."""
         url = f"{BASE_URL}/api/v1/products/{product_id}/categories"
         try:
-            response = await self._run_in_executor(session.get, url)
-            if response.status_code == 404:
-                return None  # Product no longer exists
-            response.raise_for_status()
-            data = response.json()
+            async with session.get(url) as response:
+                if response.status == 404:
+                    return None  # Product no longer exists
+                response.raise_for_status()
+                data = await response.json(content_type=None)
             return data.get("categories", [])
-        except RequestException as err:
+        except _NETWORK_ERRORS as err:
             _LOGGER.debug(f"Could not fetch categories for product {product_id}: {err}")
             return []
 
-    async def get_product_detail(self, session, product_id: int) -> dict | None:
+    async def get_product_detail(self, session: aiohttp.ClientSession, product_id: int) -> dict | None:
         """Fetch product detail including brand."""
         url = f"{BASE_URL}/api/v1/products/{product_id}"
         try:
-            response = await self._run_in_executor(session.get, url)
-            response.raise_for_status()
-            return response.json()
-        except RequestException as err:
+            async with session.get(url) as response:
+                response.raise_for_status()
+                return await response.json(content_type=None)
+        except _NETWORK_ERRORS as err:
             _LOGGER.debug(f"Could not fetch product detail for {product_id}: {err}")
             return None
 
     async def enrich_orders_with_items(self, order_ids: list[str]) -> dict[str, list]:
         """Fetch item details for a list of order IDs. Returns {order_id: items_list}."""
-        session = requests.Session()
+        session = self._new_session()
         results = {}
         try:
             await self.login(session)
         except Exception as err:
             _LOGGER.error(f"Login failed for order enrichment: {err}")
-            await self._run_in_executor(session.close)
+            await session.close()
             return results
 
         try:
@@ -332,17 +316,17 @@ class RohlikCZAPI:
                 await self.logout(session)
             except Exception:
                 pass
-            await self._run_in_executor(session.close)
+            await session.close()
 
     async def fetch_product_categories_batch(self, product_ids: list[int], progress_callback=None) -> dict[int, list]:
         """Fetch categories for a batch of product IDs. Returns {product_id: categories_list}."""
-        session = requests.Session()
+        session = self._new_session()
         results = {}
         try:
             await self.login(session)
         except Exception as err:
             _LOGGER.error(f"Login failed for category fetch: {err}")
-            await self._run_in_executor(session.close)
+            await session.close()
             return results
 
         try:
@@ -369,11 +353,11 @@ class RohlikCZAPI:
                 await self.logout(session)
             except Exception:
                 pass
-            await self._run_in_executor(session.close)
+            await session.close()
 
     async def fetch_all_delivered_orders(self) -> list:
         """Fetch ALL delivered orders by paginating through the API. Returns list of all orders."""
-        session = requests.Session()
+        session = self._new_session()
         all_orders = []
         offset = 0
         limit = 50
@@ -395,12 +379,12 @@ class RohlikCZAPI:
 
             return all_orders
 
-        except RequestException as err:
+        except _NETWORK_ERRORS as err:
             _LOGGER.error(f"Error during full order history fetch: {err}")
             return all_orders
         finally:
             await self.logout(session)
-            await self._run_in_executor(session.close)
+            await session.close()
 
     async def add_to_cart(self, product_list: list[dict]) -> dict:
         """
@@ -412,10 +396,10 @@ class RohlikCZAPI:
             list: A list of product IDs that were successfully added to the cart
         """
 
-        session = requests.Session()
-        await self.login(session)
-
+        session = self._new_session()
         try:
+            await self.login(session)
+
             search_url = "/services/frontend-service/v2/cart"
             added_products = []
 
@@ -428,24 +412,23 @@ class RohlikCZAPI:
                     "source": "true:Shopping Lists"
                 }
                 try:
-                    search_response = await self._run_in_executor(
-                        session.post,
-                        f"{BASE_URL}{search_url}",
-                        json=search_payload
-                    )
-                    search_response.raise_for_status()
+                    async with session.post(f"{BASE_URL}{search_url}", json=search_payload) as response:
+                        response.raise_for_status()
                     added_products.append(product["product_id"])
-                except RequestException as err:
-                    _LOGGER.error(f"Error adding {product["product_id"]} due to {err}")
+                except _NETWORK_ERRORS as err:
+                    _LOGGER.error(f"Error adding {product['product_id']} due to {err}")
 
-            return {"added_products":added_products}
+            return {"added_products": added_products}
 
-        except RequestException as err:
+        except _NETWORK_ERRORS as err:
             _LOGGER.error(f"Request failed: {err}")
             raise ValueError("Request failed")
         finally:
-            await self.logout(session)
-            await self._run_in_executor(session.close)
+            try:
+                await self.logout(session)
+            except Exception:
+                pass
+            await session.close()
 
     async def search_product(self, product_name: str, limit: int = 10, favourite: bool = False):
         """
@@ -460,33 +443,29 @@ class RohlikCZAPI:
             dict: The first matching product's details, or None if no products found
         """
 
-        session = requests.Session()
-        await self.login(session)
-
+        session = self._new_session()
         try:
-            # Set request data
-            search_url = "/services/frontend-service/search-metadata"
-            search_payload = {
-                "search": product_name,
-                "offset": 0,
-                "limit": limit + 5,
-                "companyId" : 1,
-                "filterData": {"filters": []},
-                "canCorrect": True
-            }
-
-            # Login to account to return user-specific data
             await self.login(session)
 
+            # Set request data
+            search_url = "/services/frontend-service/search-metadata"
+            # aiohttp query params must be flat strings, so complex values are
+            # JSON-encoded / stringified.
+            search_payload = {
+                "search": product_name,
+                "offset": "0",
+                "limit": str(limit + 5),
+                "companyId": "1",
+                "filterData": json.dumps({"filters": []}),
+                "canCorrect": "true",
+            }
+
             # Perform API request
-            search_response = await self._run_in_executor(
-                session.get,
-                f"{BASE_URL}{search_url}",
-                params=search_payload
-            )
-            search_response.raise_for_status()
-            search_data:dict = search_response.json()
-            found_products:list = search_data["data"]["productList"]
+            async with session.get(f"{BASE_URL}{search_url}", params=search_payload) as response:
+                response.raise_for_status()
+                search_data: dict = await response.json(content_type=None)
+
+            found_products: list = search_data["data"]["productList"]
 
             # Remove sponsored content
             found_products = [p for p in found_products if
@@ -506,7 +485,7 @@ class RohlikCZAPI:
                     search_results["search_results"].append({
                         "id": found_products[i]["productId"],
                         "name": found_products[i]["productName"],
-                        "price": f"{found_products[i]["price"]["full"]} {found_products[i]["price"]["currency"]}",
+                        "price": f"{found_products[i]['price']['full']} {found_products[i]['price']['currency']}",
                         "brand": found_products[i]["brand"],
                         "amount": found_products[i]["textualAmount"]
                             })
@@ -514,12 +493,15 @@ class RohlikCZAPI:
             else:
                 return None
 
-        except RequestException as err:
+        except _NETWORK_ERRORS as err:
             _LOGGER.error(f"Request failed: {err}")
             return None
         finally:
-            await self.logout(session)
-            await self._run_in_executor(session.close)
+            try:
+                await self.logout(session)
+            except Exception:
+                pass
+            await session.close()
 
     async def get_shopping_list(self, shopping_list_id=None) -> dict:
         """
@@ -532,31 +514,30 @@ class RohlikCZAPI:
             dict: The shopping list details
         """
 
-        session = requests.Session()
+        if not shopping_list_id:
+            raise ValueError("Missing argument - shopping list id")
 
+        session = self._new_session()
         try:
-            if not shopping_list_id:
-                raise ValueError("Missing argument - shopping list id")
-
             shopping_list_url = f"/api/v1/shopping-lists/id/{shopping_list_id}"
 
             await self.login(session)
-            search_response = await self._run_in_executor(
-                session.get,
-                f"{BASE_URL}{shopping_list_url}",
-            )
-            search_response.raise_for_status()
-            search_data = search_response.json()
+            async with session.get(f"{BASE_URL}{shopping_list_url}") as response:
+                response.raise_for_status()
+                search_data = await response.json(content_type=None)
             return {"name": search_data["name"], "products_in_list": search_data["products"]}
 
-        except RequestException as err:
+        except _NETWORK_ERRORS as err:
             _LOGGER.error(f"Request failed: {err}")
             raise ValueError("Request failed")
         finally:
-            await self.logout(session)
-            await self._run_in_executor(session.close)
+            try:
+                await self.logout(session)
+            except Exception:
+                pass
+            await session.close()
 
-    async def get_cart_content(self, logged_in: bool = False, session = None) -> Dict:
+    async def get_cart_content(self, logged_in: bool = False, session: aiohttp.ClientSession = None) -> Dict:
         """
         Fetches the current cart contents
 
@@ -566,23 +547,23 @@ class RohlikCZAPI:
         cart_url = "/services/frontend-service/v2/cart"
 
         if not logged_in:
-            session = requests.Session()
+            session = self._new_session()
             await self.login(session)
         try:
-            cart_response = await self._run_in_executor(
-                session.get,
-                f"{BASE_URL}{cart_url}",
-            )
-            cart_response.raise_for_status()
-            cart_content = cart_response.json()
+            async with session.get(f"{BASE_URL}{cart_url}") as response:
+                response.raise_for_status()
+                cart_content = await response.json(content_type=None)
 
-        except RequestException as err:
+        except _NETWORK_ERRORS as err:
             _LOGGER.error(f"Request failed: {err}")
             raise ValueError("Request failed")
         finally:
             if not logged_in:
-                await self.logout(session)
-                await self._run_in_executor(session.close)
+                try:
+                    await self.logout(session)
+                except Exception:
+                    pass
+                await session.close()
 
         data = cart_content.get("data", {})
 
@@ -621,28 +602,27 @@ class RohlikCZAPI:
         Returns:
             dict: Response from the deletion operation
         """
-        session = requests.Session()
+        session = self._new_session()
 
         try:
             await self.login(session)
 
             delete_url = f"/services/frontend-service/v2/cart?orderFieldId={order_field_id}"
 
-            delete_response = await self._run_in_executor(
-                session.delete,
-                f"{BASE_URL}{delete_url}"
-            )
-            delete_response.raise_for_status()
+            async with session.delete(f"{BASE_URL}{delete_url}") as response:
+                response.raise_for_status()
+                try:
+                    return await response.json(content_type=None)
+                except (aiohttp.ClientError, ValueError):
+                    # Handle case where response might not be JSON
+                    return {"success": True, "status_code": response.status}
 
-            try:
-                return delete_response.json()
-            except:
-                # Handle case where response might not be JSON
-                return {"success": True, "status_code": delete_response.status_code}
-
-        except RequestException as err:
+        except _NETWORK_ERRORS as err:
             _LOGGER.error(f"Error deleting item with orderFieldId {order_field_id}: {err}")
             raise APIRequestFailedError(f"Failed to delete item from cart: {err}")
         finally:
-            await self.logout(session)
-            await self._run_in_executor(session.close)
+            try:
+                await self.logout(session)
+            except Exception:
+                pass
+            await session.close()

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,1 +1,2 @@
 pytest-homeassistant-custom-component
+aioresponses

--- a/tests/test_rohlik_api.py
+++ b/tests/test_rohlik_api.py
@@ -204,6 +204,14 @@ async def test_fetch_all_delivered_orders_survives_logout_failure() -> None:
     assert orders == [{"id": 1}, {"id": 2}]
 
 
+async def test_get_cart_content_standalone_login_failure() -> None:
+    """Standalone get_cart_content surfaces a login error (and closes its session)."""
+    with aioresponses() as m:
+        m.post(LOGIN_URL, payload={"status": 401, "messages": [{"content": "Bad creds"}]})
+        with pytest.raises(InvalidCredentialsError):
+            await _api().get_cart_content()
+
+
 async def test_delete_from_cart_returns_json() -> None:
     with aioresponses() as m:
         m.post(LOGIN_URL, payload=LOGIN_OK)

--- a/tests/test_rohlik_api.py
+++ b/tests/test_rohlik_api.py
@@ -188,6 +188,22 @@ async def test_search_product_filters_promoted() -> None:
     assert result["search_results"][0]["price"] == "99 CZK"
 
 
+async def test_fetch_all_delivered_orders_survives_logout_failure() -> None:
+    """A failing logout in the finally must not lose the fetched orders."""
+    with aioresponses() as m:
+        m.post(LOGIN_URL, payload=LOGIN_OK)
+        # Single short page -> pagination stops after one request.
+        m.get(
+            f"{BASE_URL}/api/v3/orders/delivered?offset=0&limit=50",
+            payload=[{"id": 1}, {"id": 2}],
+        )
+        m.post(LOGOUT_URL, exception=aiohttp.ClientConnectionError("logout down"))
+
+        orders = await _api().fetch_all_delivered_orders()
+
+    assert orders == [{"id": 1}, {"id": 2}]
+
+
 async def test_delete_from_cart_returns_json() -> None:
     with aioresponses() as m:
         m.post(LOGIN_URL, payload=LOGIN_OK)

--- a/tests/test_rohlik_api.py
+++ b/tests/test_rohlik_api.py
@@ -1,0 +1,202 @@
+"""Tests for the aiohttp-based RohlikCZAPI client (HTTP layer mocked)."""
+from __future__ import annotations
+
+import re
+
+import aiohttp
+import pytest
+from aioresponses import aioresponses
+
+from custom_components.rohlikcz.errors import (
+    APIRequestFailedError,
+    InvalidCredentialsError,
+    RohlikczError,
+)
+from custom_components.rohlikcz.rohlik_api import BASE_URL, RohlikCZAPI
+
+LOGIN_URL = f"{BASE_URL}/services/frontend-service/login"
+LOGOUT_URL = f"{BASE_URL}/services/frontend-service/logout"
+
+LOGIN_OK = {"status": 200, "data": {"user": {"id": 123, "name": "Test User"}}}
+LOGOUT_OK = {"status": 200}
+
+
+def _api() -> RohlikCZAPI:
+    return RohlikCZAPI("user@example.com", "secret")
+
+
+async def test_login_success_sets_user_id() -> None:
+    with aioresponses() as m:
+        m.post(LOGIN_URL, payload=LOGIN_OK)
+        api = _api()
+        session = api._new_session()
+        try:
+            reply = await api.login(session)
+        finally:
+            await session.close()
+    assert reply["data"]["user"]["id"] == 123
+    assert api._user_id == 123
+    assert api._address_id is None
+
+
+async def test_login_invalid_credentials() -> None:
+    with aioresponses() as m:
+        m.post(LOGIN_URL, payload={"status": 401, "messages": [{"content": "Bad creds"}]})
+        api = _api()
+        session = api._new_session()
+        try:
+            with pytest.raises(InvalidCredentialsError, match="Bad creds"):
+                await api.login(session)
+        finally:
+            await session.close()
+
+
+async def test_login_other_error_raises_rohlikcz() -> None:
+    with aioresponses() as m:
+        m.post(LOGIN_URL, payload={"status": 500, "messages": []})
+        api = _api()
+        session = api._new_session()
+        try:
+            with pytest.raises(RohlikczError, match="status code 500"):
+                await api.login(session)
+        finally:
+            await session.close()
+
+
+async def test_login_network_error() -> None:
+    with aioresponses() as m:
+        m.post(LOGIN_URL, exception=aiohttp.ClientConnectionError("boom"))
+        api = _api()
+        session = api._new_session()
+        try:
+            with pytest.raises(APIRequestFailedError):
+                await api.login(session)
+        finally:
+            await session.close()
+
+
+async def test_get_data_aggregates_endpoints() -> None:
+    cart_payload = {
+        "data": {
+            "totalPrice": 100,
+            "submitConditionPassed": True,
+            "items": {
+                "111": {
+                    "orderFieldId": "f1",
+                    "productName": "Milk",
+                    "quantity": 2,
+                    "price": 40,
+                    "primaryCategoryName": "Dairy",
+                    "brand": "BrandX",
+                }
+            },
+        }
+    }
+    with aioresponses() as m:
+        m.post(LOGIN_URL, payload=LOGIN_OK)
+        m.get(f"{BASE_URL}/services/frontend-service/first-delivery?reasonableDeliveryTime=true", payload={"data": {}})
+        m.get(f"{BASE_URL}/api/v3/orders/upcoming", payload=[])
+        m.get(f"{BASE_URL}/services/frontend-service/announcements/top", payload={"data": {"announcements": []}})
+        m.get(f"{BASE_URL}/api/v1/reusable-bags/user-info", payload={"data": {}})
+        m.get(f"{BASE_URL}/services/frontend-service/v1/timeslot-reservation", payload=None)
+        m.get(f"{BASE_URL}/api/v3/orders/delivered?offset=0&limit=1", payload=[])
+        m.get(f"{BASE_URL}/services/frontend-service/premium/profile", payload={"data": {}})
+        m.get(f"{BASE_URL}/services/frontend-service/announcements/delivery", payload={"data": {"announcements": []}})
+        m.get(f"{BASE_URL}/api/v3/orders/delivered?offset=0&limit=50", payload=[])
+        m.get(f"{BASE_URL}/services/frontend-service/v2/cart", payload=cart_payload)
+        m.post(LOGOUT_URL, payload=LOGOUT_OK)
+
+        result = await _api().get_data()
+
+    assert result["login"]["data"]["user"]["id"] == 123
+    # No address in login -> delivery slot endpoint skipped.
+    assert result["next_delivery_slot"] is None
+    assert result["cart"]["total_items"] == 1
+    assert result["cart"]["products"][0]["name"] == "Milk"
+    assert result["cart"]["can_make_order"] is True
+
+
+async def test_get_data_endpoint_failure_is_isolated() -> None:
+    with aioresponses() as m:
+        m.post(LOGIN_URL, payload=LOGIN_OK)
+        m.get(f"{BASE_URL}/services/frontend-service/first-delivery?reasonableDeliveryTime=true", status=500)
+        m.get(f"{BASE_URL}/api/v3/orders/upcoming", payload=[1, 2])
+        m.get(f"{BASE_URL}/services/frontend-service/announcements/top", payload={"data": {"announcements": []}})
+        m.get(f"{BASE_URL}/api/v1/reusable-bags/user-info", payload={"data": {}})
+        m.get(f"{BASE_URL}/services/frontend-service/v1/timeslot-reservation", payload=None)
+        m.get(f"{BASE_URL}/api/v3/orders/delivered?offset=0&limit=1", payload=[])
+        m.get(f"{BASE_URL}/services/frontend-service/premium/profile", payload={"data": {}})
+        m.get(f"{BASE_URL}/services/frontend-service/announcements/delivery", payload={"data": {"announcements": []}})
+        m.get(f"{BASE_URL}/api/v3/orders/delivered?offset=0&limit=50", payload=[])
+        m.get(f"{BASE_URL}/services/frontend-service/v2/cart", payload={"data": {}})
+        m.post(LOGOUT_URL, payload=LOGOUT_OK)
+
+        result = await _api().get_data()
+
+    # The failing endpoint becomes None; the others still populate.
+    assert result["delivery"] is None
+    assert result["next_order"] == [1, 2]
+
+
+async def test_add_to_cart_returns_added_products() -> None:
+    with aioresponses() as m:
+        m.post(LOGIN_URL, payload=LOGIN_OK)
+        m.post(f"{BASE_URL}/services/frontend-service/v2/cart", payload={"ok": True})
+        m.post(LOGOUT_URL, payload=LOGOUT_OK)
+
+        result = await _api().add_to_cart([{"product_id": 555, "quantity": 2}])
+
+    assert result == {"added_products": [555]}
+
+
+async def test_search_product_filters_promoted() -> None:
+    search_payload = {
+        "data": {
+            "productList": [
+                {
+                    "productId": 1,
+                    "productName": "Coffee",
+                    "price": {"full": 99, "currency": "CZK"},
+                    "brand": "Tchibo",
+                    "textualAmount": "250 g",
+                    "badge": [],
+                },
+                {
+                    "productId": 2,
+                    "productName": "Sponsored Coffee",
+                    "price": {"full": 120, "currency": "CZK"},
+                    "brand": "Ad",
+                    "textualAmount": "250 g",
+                    "badge": [{"slug": "promoted"}],
+                },
+            ]
+        }
+    }
+    with aioresponses() as m:
+        m.post(LOGIN_URL, payload=LOGIN_OK)
+        # Search builds query params, so match the path regardless of them.
+        m.get(
+            re.compile(r"^https://www\.rohlik\.cz/services/frontend-service/search-metadata"),
+            payload=search_payload,
+        )
+        m.post(LOGOUT_URL, payload=LOGOUT_OK)
+
+        result = await _api().search_product("coffee", limit=10)
+
+    ids = [r["id"] for r in result["search_results"]]
+    assert ids == [1]  # promoted item filtered out
+    assert result["search_results"][0]["price"] == "99 CZK"
+
+
+async def test_delete_from_cart_returns_json() -> None:
+    with aioresponses() as m:
+        m.post(LOGIN_URL, payload=LOGIN_OK)
+        m.delete(
+            f"{BASE_URL}/services/frontend-service/v2/cart?orderFieldId=f1",
+            payload={"status": 200},
+        )
+        m.post(LOGOUT_URL, payload=LOGOUT_OK)
+
+        result = await _api().delete_from_cart("f1")
+
+    assert result == {"status": 200}


### PR DESCRIPTION
Follow-up #1 from the modernization PR (#70): replace the blocking `requests.Session` + `run_in_executor` shim in `rohlik_api.py` with native **aiohttp**, removing thread-pool churn and aligning with the HA quality-scale expectation of non-blocking I/O.

## Approach

- **Isolated session per operation.** Each public method creates its own `aiohttp.ClientSession` (private cookie jar) via `_new_session()` and closes it in `finally`. This preserves the original per-operation login/logout isolation — important here because the API authenticates **per operation**, so a single shared session would clash cookies between a regular refresh and a concurrent background enrichment or service call.
- **Error mapping.** Network failures map to `aiohttp.ClientError` / `asyncio.TimeoutError` → `APIRequestFailedError`. The login/logout status-code checks and credential-error handling (`InvalidCredentialsError` / `RohlikczError`, including the empty-`messages` guard) are unchanged.
- **JSON** parsed with `content_type=None` to match the previous `requests.json()` behaviour regardless of the server's content-type header.
- **Robustness.** Per-endpoint and cart fetch failures in `get_data` are isolated (set to `None`) rather than failing the whole refresh; `logout()` in `finally` is best-effort so it never masks a login error, and the session is always closed.
- Uses `HTTP_TIMEOUT` (`ClientTimeout(total=10)`, already in `const.py`) for request timeouts.
- `requests` is fully removed from the codebase.

## Tests

New `tests/test_rohlik_api.py` (via `aioresponses`, added to `requirements_test.txt`) covers:
- `login` — success (sets `user_id`), invalid credentials (401), other API error (500), network error
- `get_data` — endpoint aggregation + cart parsing; a single failing endpoint is isolated to `None`
- `add_to_cart`, `search_product` (promoted-item filtering), `delete_from_cart`

**26 tests pass** (17 existing + 9 new) on Python 3.13 / HA 2026.2.3.

## ⚠️ Caveat — couldn't validate against the live API

This was the follow-up I flagged as un-verifiable without hitting the real Rohlik server. The HTTP layer is fully mocked, so I could not confirm:
- the exact cookie/auth handshake behaves identically under aiohttp,
- the **search query-param encoding** — aiohttp requires flat string params, so the nested `filterData` is now `json.dumps({"filters": []})` and booleans/ints are stringified. This differs from how `requests` encoded the original dict; functionally equivalent but worth a real-world smoke test of the `search_product` service.

Recommend a quick manual check of login + a search after merge. Happy to adjust.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015TqvRozwrnqt3NgyaYeBZe

---
_Generated by [Claude Code](https://claude.ai/code/session_015TqvRozwrnqt3NgyaYeBZe)_