### PR TITLE
Back OrderStore with HA Store helper (with legacy file import)

### DIFF
--- a/custom_components/rohlikcz/hub.py
+++ b/custom_components/rohlikcz/hub.py
@@ -92,7 +92,7 @@ class OrderStore:
         # No Store data yet: import the legacy file if one exists.
         legacy = await self._hass.async_add_executor_job(self._load_legacy_sync)
         if legacy is not None:
-            self._data = self._migrate_legacy(legacy)
+            self._data = self._migrate_legacy(legacy, self._user_id)
             await self._store.async_save(self._data)
             await self._hass.async_add_executor_job(self._remove_legacy_sync)
             _LOGGER.info("Imported legacy order store for user %s into HA storage", self._user_id)
@@ -105,21 +105,22 @@ class OrderStore:
             with open(self._legacy_path, "r") as f:
                 return json.load(f)
         except (json.JSONDecodeError, OSError) as err:
-            _LOGGER.error(f"Failed to load legacy order store: {err}")
+            _LOGGER.error("Failed to load legacy order store: %s", err)
             return None
 
     def _remove_legacy_sync(self) -> None:
         """Delete the legacy JSON file after a successful import."""
         try:
             os.remove(self._legacy_path)
-        except OSError:
-            pass
+        except OSError as err:
+            _LOGGER.warning("Could not remove legacy order store file %s: %s", self._legacy_path, err)
 
     @staticmethod
-    def _migrate_legacy(data: dict) -> dict:
+    def _migrate_legacy(data: dict, user_id: str = "") -> dict:
         """Bring imported legacy data up to the current schema (v1/v2 -> v3)."""
         if not isinstance(data, dict):
-            return OrderStore._default_data("")
+            return OrderStore._default_data(user_id)
+        data = dict(data)  # avoid mutating the caller's dict
         data.setdefault("orders", {})
         data.setdefault("product_categories", {})
         if "backfill_complete" not in data:

--- a/custom_components/rohlikcz/hub.py
+++ b/custom_components/rohlikcz/hub.py
@@ -11,6 +11,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.storage import Store
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from .const import DOMAIN
 from .errors import InvalidCredentialsError, APIRequestFailedError, RohlikczError
@@ -53,64 +54,83 @@ _NOTIFICATIONS = {
 }
 
 
-class OrderStore:
-    """Persistent storage for order history in HA's .storage directory."""
+#: Storage schema version for the order store.
+STORE_VERSION = 3
 
-    def __init__(self, storage_dir: str, user_id: str, hass: HomeAssistant):
-        self._path = os.path.join(storage_dir, f"rohlikcz_{user_id}_orders.json")
-        self._data = {"version": 3, "user_id": user_id, "tracking_since": None, "backfill_complete": False, "orders": {}, "product_categories": {}}
+
+class OrderStore:
+    """Persistent storage for order history backed by Home Assistant's Store helper."""
+
+    def __init__(self, hass: HomeAssistant, user_id: str):
         self._hass = hass
+        self._user_id = user_id
+        self._key = f"rohlikcz_{user_id}_orders"
+        self._store: Store[dict] = Store(hass, STORE_VERSION, self._key)
+        # Path of the pre-Store implementation, imported once if present.
+        self._legacy_path = hass.config.path(".storage", f"{self._key}.json")
+        self._data = self._default_data(user_id)
+
+    @staticmethod
+    def _default_data(user_id: str) -> dict:
+        return {"version": STORE_VERSION, "user_id": user_id, "tracking_since": None,
+                "backfill_complete": False, "orders": {}, "product_categories": {}}
 
     @classmethod
-    async def async_create(cls, storage_dir: str, user_id: str, hass: HomeAssistant) -> "OrderStore":
+    async def async_create(cls, hass: HomeAssistant, user_id: str) -> "OrderStore":
         """Create and load an OrderStore asynchronously."""
-        store = cls(storage_dir, user_id, hass)
-        await hass.async_add_executor_job(store._load_sync)
+        store = cls(hass, user_id)
+        await store._async_load()
         return store
 
-    def _load_sync(self) -> None:
-        """Load order store from disk (blocking, run in executor)."""
-        if os.path.exists(self._path):
-            try:
-                with open(self._path, "r") as f:
-                    self._data = json.load(f)
-                migrated = False
-                # Migrate v1 → v2
-                if self._data.get("version", 1) < 2:
-                    self._data["version"] = 2
-                    if "product_categories" not in self._data:
-                        self._data["product_categories"] = {}
-                    migrated = True
-                    _LOGGER.info("Migrated order store from v1 to v2")
-                elif "product_categories" not in self._data:
-                    self._data["product_categories"] = {}
-                # Migrate v2 → v3 (add backfill_complete flag)
-                if self._data.get("version", 1) < 3:
-                    self._data["version"] = 3
-                    # Existing stores with tracking_since already set had a
-                    # successful backfill in a prior run; mark it complete so
-                    # we don't re-download everything on next restart.
-                    if "backfill_complete" not in self._data:
-                        self._data["backfill_complete"] = self._data.get("tracking_since") is not None
-                    migrated = True
-                    _LOGGER.info("Migrated order store from v2 to v3")
-                if migrated:
-                    self._save_sync()
-            except (json.JSONDecodeError, OSError) as err:
-                _LOGGER.error(f"Failed to load order store: {err}")
+    async def _async_load(self) -> None:
+        """Load from Store, importing the legacy JSON file on first run."""
+        data = await self._store.async_load()
+        if data is not None:
+            self._data = data
+            return
 
-    def _save_sync(self) -> None:
-        """Save order store to disk (blocking, run in executor)."""
+        # No Store data yet: import the legacy file if one exists.
+        legacy = await self._hass.async_add_executor_job(self._load_legacy_sync)
+        if legacy is not None:
+            self._data = self._migrate_legacy(legacy)
+            await self._store.async_save(self._data)
+            await self._hass.async_add_executor_job(self._remove_legacy_sync)
+            _LOGGER.info("Imported legacy order store for user %s into HA storage", self._user_id)
+
+    def _load_legacy_sync(self) -> dict | None:
+        """Read the legacy JSON file (blocking, run in executor)."""
+        if not os.path.exists(self._legacy_path):
+            return None
         try:
-            os.makedirs(os.path.dirname(self._path), exist_ok=True)
-            with open(self._path, "w") as f:
-                json.dump(self._data, f, indent=2)
-        except OSError as err:
-            _LOGGER.error(f"Failed to save order store: {err}")
+            with open(self._legacy_path, "r") as f:
+                return json.load(f)
+        except (json.JSONDecodeError, OSError) as err:
+            _LOGGER.error(f"Failed to load legacy order store: {err}")
+            return None
+
+    def _remove_legacy_sync(self) -> None:
+        """Delete the legacy JSON file after a successful import."""
+        try:
+            os.remove(self._legacy_path)
+        except OSError:
+            pass
+
+    @staticmethod
+    def _migrate_legacy(data: dict) -> dict:
+        """Bring imported legacy data up to the current schema (v1/v2 -> v3)."""
+        if not isinstance(data, dict):
+            return OrderStore._default_data("")
+        data.setdefault("orders", {})
+        data.setdefault("product_categories", {})
+        if "backfill_complete" not in data:
+            # A store that already had a tracking_since had completed backfill.
+            data["backfill_complete"] = data.get("tracking_since") is not None
+        data["version"] = STORE_VERSION
+        return data
 
     async def async_save(self) -> None:
-        """Save order store to disk asynchronously."""
-        await self._hass.async_add_executor_job(self._save_sync)
+        """Persist the order store asynchronously."""
+        await self._store.async_save(self._data)
 
     def process_orders(self, orders: list) -> int:
         """Process a list of order dicts from the API. Returns count of new orders added.
@@ -453,8 +473,7 @@ class RohlikAccount(DataUpdateCoordinator[dict]):
         # Initialize order store on first update (only if analytics enabled)
         if self._analytics and not self._order_store and data.get("login"):
             user_id = str(data["login"]["data"]["user"]["id"])
-            storage_dir = self.hass.config.path(".storage")
-            self._order_store = await OrderStore.async_create(storage_dir, user_id, self.hass)
+            self._order_store = await OrderStore.async_create(self.hass, user_id)
 
         # Process delivered orders into persistent store and auto-enrich new ones
         if self._analytics and self._order_store and data.get("delivered_orders"):

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,6 +1,8 @@
 """Tests for setup, coordinator behaviour, and unloading."""
 from __future__ import annotations
 
+import json
+import os
 from datetime import timedelta
 from unittest.mock import AsyncMock, patch
 
@@ -175,7 +177,34 @@ async def test_monthly_spent_sums_current_month(hass: HomeAssistant) -> None:
     assert hass.states.get(spent_id).state == "500.0"
 
 
-async def test_auto_enrich_applies_items_and_categories(hass: HomeAssistant, tmp_path) -> None:
+async def test_order_store_imports_legacy_file(hass: HomeAssistant, hass_storage) -> None:
+    """A pre-Store JSON file is imported once into Store and then removed."""
+    storage_dir = hass.config.path(".storage")
+    os.makedirs(storage_dir, exist_ok=True)
+    legacy_path = os.path.join(storage_dir, "rohlikcz_999_orders.json")
+    legacy = {
+        "version": 1,
+        "user_id": "999",
+        "tracking_since": "2026-01-01T00:00:00+01:00",
+        "orders": {"1": {"date": "2026-01-15", "amount": 100.0}},
+    }
+    with open(legacy_path, "w") as f:
+        json.dump(legacy, f)
+
+    store = await OrderStore.async_create(hass, "999")
+
+    # Orders imported.
+    assert store.alltime_count() == 1
+    assert store.alltime_total() == 100.0
+    # v1 -> v3 schema fields filled in.
+    assert store.backfill_complete is True  # tracking_since was set
+    assert "product_categories" in store._data
+    # Legacy file removed; data now lives in HA Store.
+    assert not os.path.exists(legacy_path)
+    assert "rohlikcz_999_orders" in hass_storage
+
+
+async def test_auto_enrich_applies_items_and_categories(hass: HomeAssistant, hass_storage) -> None:
     """Auto-enrichment fetches items + categories and persists them.
 
     Also guards the refactor that releases the store lock during network I/O.
@@ -191,7 +220,7 @@ async def test_auto_enrich_applies_items_and_categories(hass: HomeAssistant, tmp
     account = RohlikAccount(
         hass, "user", "pass", analytics=["categories_l1"], entry=entry
     )
-    store = await OrderStore.async_create(str(tmp_path), "123456", hass)
+    store = await OrderStore.async_create(hass, "123456")
     store.process_orders(
         [
             {
@@ -226,7 +255,7 @@ async def test_auto_enrich_applies_items_and_categories(hass: HomeAssistant, tmp
     assert store.get_product_category(111, 1) == "Dairy"
 
 
-async def test_enrich_order_details_applies_results(hass: HomeAssistant, tmp_path) -> None:
+async def test_enrich_order_details_applies_results(hass: HomeAssistant, hass_storage) -> None:
     """The enrich_orders service path enriches items + categories.
 
     Guards the lock-split refactor in _enrich_order_details / enrich_order_details.
@@ -242,7 +271,7 @@ async def test_enrich_order_details_applies_results(hass: HomeAssistant, tmp_pat
     account = RohlikAccount(
         hass, "user", "pass", analytics=["categories_l1"], entry=entry
     )
-    store = await OrderStore.async_create(str(tmp_path), "123456", hass)
+    store = await OrderStore.async_create(hass, "123456")
     store.process_orders(
         [
             {


### PR DESCRIPTION
Follow-up #3 from the modernization work: replace the hand-rolled JSON file I/O in `OrderStore` with **`homeassistant.helpers.storage.Store`**, the idiomatic HA persistence helper (atomic writes, debounced saves, versioned schema).

## What changed

- `OrderStore` now wraps a `Store(hass, STORE_VERSION, "rohlikcz_<uid>_orders")` instead of manually `open()`/`json.dump`-ing into `.storage`.
- **Seamless migration for existing users:** on first load, if Store has no data yet, the previous `.storage/rohlikcz_<uid>_orders.json` file is imported once — with the historical v1/v2 → v3 field migrations applied (`product_categories`, `backfill_complete` derived from `tracking_since`) — then the legacy file is removed.
- `async_create()` signature is now `(hass, user_id)` (dropped the `storage_dir` arg); the coordinator call site is updated. All the data-manipulation methods (`process_orders`, `yearly_total`, `alltime_total`, enrichment helpers, …) are unchanged — only the load/save layer moved.

## Tests

- New `test_order_store_imports_legacy_file` — writes a v1-format legacy JSON file, asserts it's imported (orders + derived `backfill_complete`), the schema is upgraded, and the legacy file is removed.
- The two enrichment tests now exercise the store via phacc's `hass_storage` fixture (in-memory, isolated per test) instead of a `tmp_path` — cleaner isolation than before.
- **29 tests pass** on Python 3.13 / HA 2026.2.3.

## Notes

- Storage moves from `.storage/rohlikcz_<uid>_orders.json` → `.storage/rohlikcz_<uid>_orders` (Store's versioned wrapper format). The import path makes this transparent on upgrade; no user action needed.
- `STORE_VERSION` stays at 3 to match the existing data schema, so no Store-level migration func is required yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015TqvRozwrnqt3NgyaYeBZe

---
_Generated by [Claude Code](https://claude.ai/code/session_015TqvRozwrnqt3NgyaYeBZe)_