### PR TITLE
Fix APIRequestFailedError docstring

### DIFF
--- a/custom_components/rohlikcz/errors.py
+++ b/custom_components/rohlikcz/errors.py
@@ -18,4 +18,4 @@ class AddressNotSetError(RohlikczError):
 
 
 class APIRequestFailedError(RohlikczError):
-    """ No delivery address set in user account. """
+    """ An API request to Rohlik.cz failed (e.g. connection error). """


### PR DESCRIPTION
`APIRequestFailedError`'s docstring was a verbatim copy of `AddressNotSetError`'s (`"No delivery address set in user account."`). Replaced it with an accurate description.

## Context

This is the one remaining "small fix" from #68 that isn't already in `master`. I audited all seven fixes that PR bundled; the other six were fixed independently during the modernization work:

| #68 fix | Status on master |
|---|---|
| `test_order_store.py` indentation | ✅ fixed (#69) |
| `search_product` double `login()` | ✅ fixed (#71) |
| `services.py` "get get cart content" typo | ✅ fixed (#70) |
| `hub.py` unused `cast`/`List` imports | ✅ fixed (#70) |
| `sensor.py` shadowed `import datetime` | ✅ fixed (#73) |
| `todo.py` truncated log + delete log level | ✅ fixed (#70) |
| **`errors.py` `APIRequestFailedError` docstring** | **this PR** |

Original credit to @MangelSpec, who spotted it in #68. (#68's main `refresh_slots` feature is separate and predates the `DataUpdateCoordinator`/`aiohttp` rework, so it'd need adapting to the new architecture — out of scope here.)

Docs-only change; the full test suite (31 tests) still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015TqvRozwrnqt3NgyaYeBZe

---
_Generated by [Claude Code](https://claude.ai/code/session_015TqvRozwrnqt3NgyaYeBZe)_