### PR TITLE
Add refresh_slots action for lightweight express-slot polling

### DIFF
--- a/automations/refresh_slots.yaml
+++ b/automations/refresh_slots.yaml
@@ -1,0 +1,35 @@
+alias: Notify when Rohlik express delivery becomes available
+description: >-
+  While an "express alert" toggle is on, poll the lightweight refresh_slots
+  action every 15 seconds so the express-available binary sensor updates within
+  seconds, and push a notification the moment express becomes available.
+mode: single
+triggers:
+  # Poll while the alert is armed.
+  - trigger: time_pattern
+    seconds: "/15"
+conditions:
+  # Replace with your own input_boolean used to arm the alert.
+  - condition: state
+    entity_id: input_boolean.rohlik_express_alert
+    state: "on"
+actions:
+  - action: rohlikcz.refresh_slots
+    data:
+      config_entry_id: XXXXXXXXXXXXXXXX # Replace with your Rohlik.cz config entry ID
+  # Give the sensor a moment to update after the refresh.
+  - delay:
+      seconds: 1
+  - if:
+      - condition: state
+        entity_id: binary_sensor.rohlik_cz_express_available # Replace with your express sensor
+        state: "on"
+    then:
+      - action: notify.mobile_app_your_phone # Replace with your notify target
+        data:
+          title: Rohlík express available
+          message: Express delivery is available now — grab a slot!
+      # Disarm so we stop polling until you re-arm it.
+      - action: input_boolean.turn_off
+        target:
+          entity_id: input_boolean.rohlik_express_alert

--- a/custom_components/rohlikcz/__init__.py
+++ b/custom_components/rohlikcz/__init__.py
@@ -106,4 +106,7 @@ async def _async_reload_entry(hass: HomeAssistant, entry: RohlikConfigEntry) -> 
 
 async def async_unload_entry(hass: HomeAssistant, entry: RohlikConfigEntry) -> bool:
     """Unload a config entry."""
-    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+    if unload_ok:
+        await entry.runtime_data.async_close()
+    return unload_ok

--- a/custom_components/rohlikcz/const.py
+++ b/custom_components/rohlikcz/const.py
@@ -58,6 +58,7 @@ SERVICE_SEARCH_AND_ADD_PRODUCT = "search_and_add_to_cart"
 SERVICE_UPDATE_DATA = "update_data"
 SERVICE_FETCH_ORDER_HISTORY = "fetch_order_history"
 SERVICE_ENRICH_ORDERS = "enrich_orders"
+SERVICE_REFRESH_SLOTS = "refresh_slots"
 
 """ Analytics options """
 CONF_ANALYTICS = "analytics"

--- a/custom_components/rohlikcz/hub.py
+++ b/custom_components/rohlikcz/hub.py
@@ -672,6 +672,23 @@ class RohlikAccount(DataUpdateCoordinator[dict]):
             "products_categorized_this_run": stats["products_categorized"],
         }
 
+    async def refresh_slots(self) -> None:
+        """Cheaply refresh only the delivery-slot data (for express-slot polling).
+
+        Updates self.data["next_delivery_slot"] in place and notifies entities,
+        without disturbing the rest of the data or the regular refresh cycle.
+        """
+        if not self.data:
+            return
+        result = await self._rohlik_api.get_timeslots()
+        if result is not None:
+            self.data["next_delivery_slot"] = result
+            self.async_update_listeners()
+
+    async def async_close(self) -> None:
+        """Release resources held by the API client (called on unload)."""
+        await self._rohlik_api.async_close()
+
     # New service methods
     async def add_to_cart(self, product_id: int, quantity: int) -> Dict:
         """Add a product to the shopping cart."""

--- a/custom_components/rohlikcz/rohlik_api.py
+++ b/custom_components/rohlikcz/rohlik_api.py
@@ -89,10 +89,81 @@ class RohlikCZAPI:
         self._user_id = None
         self._address_id = None
         self.endpoints = {}
+        # A dedicated, reusable logged-in session for cheap slot polling. It has
+        # its own cookie jar (separate from the per-operation sessions), so it
+        # never clashes with get_data/service calls. Access is serialized.
+        self._slot_session: aiohttp.ClientSession | None = None
+        self._slot_lock = asyncio.Lock()
 
     def _new_session(self) -> aiohttp.ClientSession:
         """Create a fresh client session with an isolated cookie jar."""
         return aiohttp.ClientSession(timeout=HTTP_TIMEOUT)
+
+    def _timeslots_url(self) -> str | None:
+        """Build the preselected-timeslots URL, or None if no address is known."""
+        if not self._address_id:
+            return None
+        return (f"{BASE_URL}/services/frontend-service/timeslots-api/0"
+                f"?userId={self._user_id}&addressId={self._address_id}&reasonableDeliveryTime=true")
+
+    async def _ensure_slot_session(self) -> aiohttp.ClientSession:
+        """Return the reusable slot session, logging in if needed."""
+        if self._slot_session is None or self._slot_session.closed:
+            session = self._new_session()
+            await self.login(session)
+            self._slot_session = session
+        return self._slot_session
+
+    async def _reset_slot_session(self) -> None:
+        """Close the reusable slot session so the next call logs in fresh."""
+        if self._slot_session is not None:
+            await self._slot_session.close()
+            self._slot_session = None
+
+    async def get_timeslots(self) -> dict | None:
+        """Fetch only the preselected delivery slots, cheaply.
+
+        Reuses a logged-in session so a poll is a single GET rather than a full
+        login/logout cycle. Re-authenticates on 401 and retries once on a
+        dropped keep-alive connection. Returns None if the account has no
+        delivery address (no slot URL to query).
+        """
+        async with self._slot_lock:
+            try:
+                return await self._fetch_timeslots()
+            except aiohttp.ClientConnectionError:
+                # Stale keep-alive connection dropped by the server between
+                # polls - rebuild the session and try once more.
+                await self._reset_slot_session()
+                try:
+                    return await self._fetch_timeslots()
+                except _NETWORK_ERRORS as err:
+                    raise APIRequestFailedError(f"Cannot fetch timeslots: {err}")
+            except (aiohttp.ClientError, asyncio.TimeoutError) as err:
+                raise APIRequestFailedError(f"Cannot fetch timeslots: {err}")
+
+    async def _fetch_timeslots(self) -> dict | None:
+        session = await self._ensure_slot_session()
+        url = self._timeslots_url()
+        if url is None:
+            return None
+        async with session.get(url) as response:
+            if response.status == 401:
+                # Session expired - log in again and retry once.
+                await self._reset_slot_session()
+                session = await self._ensure_slot_session()
+                url = self._timeslots_url()
+                if url is None:
+                    return None
+                async with session.get(url) as retry:
+                    retry.raise_for_status()
+                    return await retry.json(content_type=None)
+            response.raise_for_status()
+            return await response.json(content_type=None)
+
+    async def async_close(self) -> None:
+        """Close the reusable slot session (call on unload)."""
+        await self._reset_slot_session()
 
     async def login(self, session: aiohttp.ClientSession):
         """

--- a/custom_components/rohlikcz/rohlik_api.py
+++ b/custom_components/rohlikcz/rohlik_api.py
@@ -148,18 +148,19 @@ class RohlikCZAPI:
         if url is None:
             return None
         async with session.get(url) as response:
-            if response.status == 401:
-                # Session expired - log in again and retry once.
-                await self._reset_slot_session()
-                session = await self._ensure_slot_session()
-                url = self._timeslots_url()
-                if url is None:
-                    return None
-                async with session.get(url) as retry:
-                    retry.raise_for_status()
-                    return await retry.json(content_type=None)
-            response.raise_for_status()
-            return await response.json(content_type=None)
+            if response.status != 401:
+                response.raise_for_status()
+                return await response.json(content_type=None)
+        # Session expired (401): the response is released as the context exits
+        # above, so it's now safe to close the session, log in again and retry.
+        await self._reset_slot_session()
+        session = await self._ensure_slot_session()
+        url = self._timeslots_url()
+        if url is None:
+            return None
+        async with session.get(url) as retry:
+            retry.raise_for_status()
+            return await retry.json(content_type=None)
 
     async def async_close(self) -> None:
         """Close the reusable slot session (call on unload)."""
@@ -267,14 +268,15 @@ class RohlikCZAPI:
             for endpoint, path in self.endpoints.items():
 
                 if endpoint == "next_delivery_slot":
-                    if self._address_id:
-                        path = self.endpoints["next_delivery_slot"] + f"0?userId={self._user_id}&addressId={self._address_id}&reasonableDeliveryTime=true"
-                    else:
+                    # Built (and DRYed) via the shared helper; None without an address.
+                    url = self._timeslots_url()
+                    if url is None:
                         result[endpoint] = None
                         continue
+                else:
+                    url = f"{BASE_URL}{path}"
 
                 try:
-                    url = f"{BASE_URL}{path}"
                     async with session.get(url) as response:
                         response.raise_for_status()
                         result[endpoint] = await response.json(content_type=None)

--- a/custom_components/rohlikcz/services.py
+++ b/custom_components/rohlikcz/services.py
@@ -10,7 +10,8 @@ from homeassistant.helpers import config_validation as cv
 
 from .const import DOMAIN, ATTR_CONFIG_ENTRY_ID, ATTR_PRODUCT_ID, ATTR_QUANTITY, ATTR_PRODUCT_NAME, \
     ATTR_SHOPPING_LIST_ID, ATTR_LIMIT, ATTR_FAVOURITE_ONLY, SERVICE_ADD_TO_CART, SERVICE_SEARCH_PRODUCT, SERVICE_GET_SHOPPING_LIST, \
-    SERVICE_GET_CART_CONTENT, SERVICE_SEARCH_AND_ADD_PRODUCT, SERVICE_UPDATE_DATA, SERVICE_FETCH_ORDER_HISTORY, SERVICE_ENRICH_ORDERS
+    SERVICE_GET_CART_CONTENT, SERVICE_SEARCH_AND_ADD_PRODUCT, SERVICE_UPDATE_DATA, SERVICE_FETCH_ORDER_HISTORY, SERVICE_ENRICH_ORDERS, \
+    SERVICE_REFRESH_SLOTS
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -123,6 +124,16 @@ def register_services(hass: HomeAssistant) -> None:
         except Exception as err:
             raise HomeAssistantError(f"Failed to update data: {err}")
 
+    async def async_refresh_slots(call: ServiceCall) -> None:
+        """Cheaply refresh only the delivery-slot data (express-slot polling)."""
+        config_entry_id = call.data[ATTR_CONFIG_ENTRY_ID]
+
+        account = _get_account(hass, config_entry_id)
+        try:
+            await account.refresh_slots()
+        except Exception as err:
+            raise HomeAssistantError(f"Failed to refresh slots: {err}")
+
 
     async def async_fetch_order_history(call: ServiceCall) -> None:
         """Fetch complete order history from Rohlik."""
@@ -212,6 +223,16 @@ def register_services(hass: HomeAssistant) -> None:
         DOMAIN,
         SERVICE_UPDATE_DATA,
         async_update_data,
+        schema=vol.Schema({
+            vol.Required(ATTR_CONFIG_ENTRY_ID): cv.string
+        }),
+        supports_response=SupportsResponse.NONE
+    )
+
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_REFRESH_SLOTS,
+        async_refresh_slots,
         schema=vol.Schema({
             vol.Required(ATTR_CONFIG_ENTRY_ID): cv.string
         }),

--- a/custom_components/rohlikcz/services.py
+++ b/custom_components/rohlikcz/services.py
@@ -134,7 +134,6 @@ def register_services(hass: HomeAssistant) -> None:
         except Exception as err:
             raise HomeAssistantError(f"Failed to refresh slots: {err}")
 
-
     async def async_fetch_order_history(call: ServiceCall) -> None:
         """Fetch complete order history from Rohlik."""
         config_entry_id = call.data[ATTR_CONFIG_ENTRY_ID]

--- a/custom_components/rohlikcz/services.yaml
+++ b/custom_components/rohlikcz/services.yaml
@@ -108,6 +108,18 @@ update_data:
         config_entry:
           integration: rohlikcz
 
+refresh_slots:
+  name: Refresh delivery slots
+  description: Cheaply refresh only the delivery-slot data (one request). Light enough to poll every few seconds to catch express availability without a full data update.
+  fields:
+    config_entry_id:
+      name: Account
+      description: The Rohlik account to use
+      required: true
+      selector:
+        config_entry:
+          integration: rohlikcz
+
 search_and_add_to_cart:
   name: Search and add to cart
   description: Search for a product and add to a shopping cart

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -177,6 +177,37 @@ async def test_monthly_spent_sums_current_month(hass: HomeAssistant) -> None:
     assert hass.states.get(spent_id).state == "500.0"
 
 
+async def test_refresh_slots_updates_express_sensor(hass: HomeAssistant) -> None:
+    """refresh_slots merges fresh slot data and the express sensor reflects it."""
+    data = sample_api_data()
+    data["next_delivery_slot"] = None  # express unavailable initially
+
+    entry = _entry()
+    entry.add_to_hass(hass)
+    with _patch_get_data(return_value=data):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    ent_reg = er.async_get(hass)
+    express_id = ent_reg.async_get_entity_id(
+        "binary_sensor", DOMAIN, "123456_is_express_available"
+    )
+    assert hass.states.get(express_id).state == "off"
+
+    account = entry.runtime_data
+    fresh_slots = {"data": {"expressSlot": {"timeSlotCapacityDTO": {"totalFreeCapacityPercent": 80}}}}
+    account._rohlik_api.get_timeslots = AsyncMock(return_value=fresh_slots)
+
+    await account.refresh_slots()
+    await hass.async_block_till_done()
+
+    # Only the slot data changed; the express sensor flips to available.
+    assert account.data["next_delivery_slot"] == fresh_slots
+    assert hass.states.get(express_id).state == "on"
+    # Other data is untouched.
+    assert account.data["login"]["data"]["user"]["id"] == 123456
+
+
 async def test_slot_sensors_registered(hass: HomeAssistant) -> None:
     """The three preselected-slot sensors register and parse their data."""
     data = sample_api_data()

--- a/tests/test_rohlik_api.py
+++ b/tests/test_rohlik_api.py
@@ -233,6 +233,24 @@ async def test_get_timeslots_reuses_session() -> None:
     assert second == slots
 
 
+async def test_get_timeslots_retries_on_401() -> None:
+    """On a 401 response, get_timeslots re-authenticates and retries once."""
+    login_with_addr = {"status": 200, "data": {"user": {"id": 123}, "address": {"id": 777}}}
+    slots = {"data": {"preselectedSlots": []}}
+    with aioresponses() as m:
+        m.post(LOGIN_URL, payload=login_with_addr)  # initial login
+        m.get(re.compile(r"^https://www\.rohlik\.cz/services/frontend-service/timeslots-api/"), status=401)
+        m.post(LOGIN_URL, payload=login_with_addr)  # re-auth after 401
+        m.get(
+            re.compile(r"^https://www\.rohlik\.cz/services/frontend-service/timeslots-api/"),
+            payload=slots,
+        )
+        api = _api()
+        result = await api.get_timeslots()
+        await api.async_close()
+    assert result == slots
+
+
 async def test_get_timeslots_no_address_returns_none() -> None:
     """Without a delivery address there is no slot URL, so None is returned."""
     with aioresponses() as m:

--- a/tests/test_rohlik_api.py
+++ b/tests/test_rohlik_api.py
@@ -212,6 +212,37 @@ async def test_get_cart_content_standalone_login_failure() -> None:
             await _api().get_cart_content()
 
 
+async def test_get_timeslots_reuses_session() -> None:
+    """get_timeslots logs in once and reuses the session across calls."""
+    login_with_addr = {"status": 200, "data": {"user": {"id": 123}, "address": {"id": 777}}}
+    slots = {"data": {"preselectedSlots": []}}
+    with aioresponses() as m:
+        # Login registered once (no repeat): a second login would 404 here.
+        m.post(LOGIN_URL, payload=login_with_addr)
+        m.get(
+            re.compile(r"^https://www\.rohlik\.cz/services/frontend-service/timeslots-api/"),
+            payload=slots,
+            repeat=True,
+        )
+        api = _api()
+        first = await api.get_timeslots()
+        second = await api.get_timeslots()  # reuses session; no second login
+        await api.async_close()
+
+    assert first == slots
+    assert second == slots
+
+
+async def test_get_timeslots_no_address_returns_none() -> None:
+    """Without a delivery address there is no slot URL, so None is returned."""
+    with aioresponses() as m:
+        m.post(LOGIN_URL, payload=LOGIN_OK)  # LOGIN_OK has no address
+        api = _api()
+        result = await api.get_timeslots()
+        await api.async_close()
+    assert result is None
+
+
 async def test_delete_from_cart_returns_json() -> None:
     with aioresponses() as m:
         m.post(LOGIN_URL, payload=LOGIN_OK)


### PR DESCRIPTION
Ports the `refresh_slots` feature from #68 (@MangelSpec) to the current `DataUpdateCoordinator` + `aiohttp` architecture.

## Motivation
The express-availability binary sensor only updates on the 600 s refresh, so it can be up to ~10 min stale — too slow to catch express slots before they're gone. `update_data` can force a refresh but does a full login + ~10 endpoint GETs + cart + logout (~12 requests), so polling it frequently would hammer the server. This adds a dedicated action that fetches **only** the timeslot endpoint, cheap enough to poll every ~15 s.

## What changed
- **`RohlikCZAPI.get_timeslots()`** — a single GET to the timeslots-api endpoint (the same URL `get_data` builds for `next_delivery_slot`), using a **dedicated, reusable logged-in session**. After the first login a poll is one request, not a login/logout cycle. It re-authenticates on `401` and retries once on a dropped keep-alive connection.
  - **Architecture note:** the original used a single shared session; here the slot session has its **own cookie jar**, separate from the per-operation sessions `get_data`/services use — so it never clashes with a concurrent refresh (the reason we moved to isolated sessions in the aiohttp PR). Access is serialized with an `asyncio.Lock`, and it's closed on unload.
- **`RohlikAccount.refresh_slots()`** — replaces only `data["next_delivery_slot"]` and calls `async_update_listeners()`, so the express sensor refreshes while every other sensor keeps its value and the **regular refresh timer is undisturbed** (no `async_set_updated_data`).
- New **`rohlikcz.refresh_slots`** service (`config_entry_id` required, `SupportsResponse.NONE`) + `services.yaml` entry, session teardown wired into `async_unload_entry`, and an example automation in `automations/refresh_slots.yaml`.

## Tests
- `get_timeslots` reuses its session across calls (a second login would fail the mock) and returns `None` when the account has no delivery address.
- `refresh_slots` flips the express binary sensor from `off` → `on` and leaves the rest of the data intact.
- **34 tests pass** on Python 3.13 / HA 2026.2.3.

## Caveat
Like the rest of the aiohttp client, the HTTP layer is mocked — the live re-auth-on-401 / keep-alive-retry behaviour against the real Rohlik server couldn't be verified here. Worth a quick smoke test (arm the example automation and watch the express sensor) before relying on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015TqvRozwrnqt3NgyaYeBZe

---
_Generated by [Claude Code](https://claude.ai/code/session_015TqvRozwrnqt3NgyaYeBZe)_