### PR TITLE
Preserve live ETA when delivery announcement clears

### DIFF
--- a/custom_components/rohlikcz/sensor.py
+++ b/custom_components/rohlikcz/sensor.py
@@ -155,6 +155,15 @@ class DeliveryTime(BaseEntity, SensorEntity, RestoreEntity):
         """Initialize the delivery time sensor."""
         super().__init__(rohlik_account)
         self._last_value: datetime | None = None
+        self._last_live_value: datetime | None = None
+        self._last_live_order_id: str | None = None
+
+    def _clear_last_live_value(self, order_id: str | None = None) -> None:
+        """Forget a live ETA, optionally only when it belongs to an order."""
+        if order_id is not None and self._last_live_order_id != order_id:
+            return
+        self._last_live_value = None
+        self._last_live_order_id = None
 
     @property
     def native_value(self) -> datetime | None:
@@ -162,14 +171,19 @@ class DeliveryTime(BaseEntity, SensorEntity, RestoreEntity):
 
         The precise delivery time comes from the delivery announcement, but with
         multiple concurrent orders the announcement may relate to a later order
-        rather than the soonest one. In that case (or once the announcement has
-        been cleared) we fall back to the delivery slot of the earliest upcoming
-        order - the same source the delivery slot sensors use - which always
-        reflects the soonest order.
+        rather than the soonest one. In that case we fall back to the delivery
+        slot of the earliest upcoming order. When the announcement is cleared,
+        preserve its last live ETA only while the same order remains the soonest
+        upcoming order.
         """
         announcements: list = self._rohlik_account.data["delivery_announcements"]["data"]["announcements"]
         upcoming_orders: list = self._rohlik_account.data.get("next_order", []) or []
         earliest_order = get_earliest_order(upcoming_orders)
+        earliest_order_id = (
+            str(earliest_order.get("id"))
+            if earliest_order is not None and earliest_order.get("id") is not None
+            else None
+        )
 
         if len(announcements) > 0:
             announcement = announcements[0]
@@ -184,7 +198,41 @@ class DeliveryTime(BaseEntity, SensorEntity, RestoreEntity):
                 delivery_time = extract_delivery_datetime(announcement.get("content", ""))
                 if delivery_time is not None:
                     self._last_value = delivery_time
+                    self._last_live_value = delivery_time
+                    self._last_live_order_id = earliest_order_id
                     return delivery_time
+
+                if (
+                    earliest_order_id is not None
+                    and self._last_live_order_id == earliest_order_id
+                    and self._last_live_value is not None
+                ):
+                    # The announcement can remain present while no longer
+                    # containing an ETA. Preserve the last precise value for
+                    # this order instead of replacing it with the booked slot.
+                    self._last_value = self._last_live_value
+                    return self._last_live_value
+
+            # An announcement for a different order must not allow an older
+            # live ETA to be resurrected after it later disappears.
+            self._clear_last_live_value(earliest_order_id)
+
+        elif (
+            earliest_order_id is not None
+            and self._last_live_order_id == earliest_order_id
+            and self._last_live_value is not None
+        ):
+            # Rohlík commonly clears the announcement shortly before delivery.
+            # Keep its precise ETA while the same order is still the soonest.
+            self._last_value = self._last_live_value
+            return self._last_live_value
+
+        if (
+            earliest_order_id is not None
+            and self._last_live_order_id is not None
+            and self._last_live_order_id != earliest_order_id
+        ):
+            self._clear_last_live_value()
 
         # Fall back to the delivery slot of the soonest order.
         if earliest_order is not None:
@@ -199,6 +247,9 @@ class DeliveryTime(BaseEntity, SensorEntity, RestoreEntity):
         # still exists so it isn't cleared shortly before delivery.
         if self._rohlik_account.is_ordered and self._last_value is not None:
             return self._last_value
+
+        if not self._rohlik_account.is_ordered:
+            self._clear_last_live_value()
         return None
 
     @property

--- a/custom_components/rohlikcz/sensor.py
+++ b/custom_components/rohlikcz/sensor.py
@@ -5,7 +5,7 @@ import logging
 import re
 
 from collections.abc import Mapping
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Any, Literal
 from zoneinfo import ZoneInfo
 from dataclasses import dataclass
@@ -14,7 +14,8 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory, STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.restore_state import RestoreEntity
+from homeassistant.helpers.restore_state import ExtraStoredData, RestoreEntity
+from homeassistant.util import dt as dt_util
 from .const import DOMAIN, ICON_UPDATE, ICON_CREDIT, ICON_NO_LIMIT, ICON_FREE_EXPRESS, ICON_DELIVERY, ICON_BAGS, \
     ICON_CART, ICON_ACCOUNT, ICON_EMAIL, ICON_PHONE, ICON_PREMIUM_DAYS, ICON_LAST_ORDER, ICON_NEXT_ORDER_SINCE, \
     ICON_NEXT_ORDER_TILL, ICON_INFO, ICON_DELIVERY_TIME, ICON_MONTHLY_SPENT, ICON_YEARLY_SPENT, ICON_ALLTIME_SPENT, \
@@ -24,6 +25,8 @@ from .hub import OrderStore, RohlikAccount
 from .utils import extract_delivery_datetime, get_earliest_order, parse_delivery_datetime_string
 
 _LOGGER = logging.getLogger(__name__)
+
+LIVE_ETA_STALE_AFTER = timedelta(hours=1)
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -144,6 +147,60 @@ class DeliveryInfo(BaseEntity, SensorEntity, RestoreEntity):
                 self._last_attributes = dict(last_state.attributes)
 
 
+@dataclass
+class DeliveryTimeExtraStoredData(ExtraStoredData):
+    """Extra stored data for a delivery time sensor."""
+
+    last_live_value: datetime | None
+    last_live_order_id: str | None
+    last_live_slot_since: datetime | None
+
+    def as_dict(self) -> dict[str, Any]:
+        """Return serializable delivery time data."""
+        return {
+            "last_live_value": (
+                self.last_live_value.isoformat()
+                if self.last_live_value is not None
+                else None
+            ),
+            "last_live_order_id": self.last_live_order_id,
+            "last_live_slot_since": (
+                self.last_live_slot_since.isoformat()
+                if self.last_live_slot_since is not None
+                else None
+            ),
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> DeliveryTimeExtraStoredData | None:
+        """Initialize stored delivery time data from a dict."""
+        try:
+            last_live_value = (
+                dt_util.parse_datetime(data["last_live_value"])
+                if data.get("last_live_value")
+                else None
+            )
+            last_live_slot_since = (
+                dt_util.parse_datetime(data["last_live_slot_since"])
+                if data.get("last_live_slot_since")
+                else None
+            )
+            last_live_order_id = data.get("last_live_order_id")
+        except (TypeError, ValueError):
+            return None
+
+        if (
+            data.get("last_live_value") is not None
+            and last_live_value is None
+        ) or (
+            data.get("last_live_slot_since") is not None
+            and last_live_slot_since is None
+        ):
+            return None
+
+        return cls(last_live_value, last_live_order_id, last_live_slot_since)
+
+
 class DeliveryTime(BaseEntity, SensorEntity, RestoreEntity):
     """Sensor for showing delivery time."""
 
@@ -157,6 +214,7 @@ class DeliveryTime(BaseEntity, SensorEntity, RestoreEntity):
         self._last_value: datetime | None = None
         self._last_live_value: datetime | None = None
         self._last_live_order_id: str | None = None
+        self._last_live_slot_since: datetime | None = None
 
     def _clear_last_live_value(self, order_id: str | None = None) -> None:
         """Forget a live ETA, optionally only when it belongs to an order."""
@@ -164,6 +222,30 @@ class DeliveryTime(BaseEntity, SensorEntity, RestoreEntity):
             return
         self._last_live_value = None
         self._last_live_order_id = None
+        self._last_live_slot_since = None
+
+    def _preserved_live_value(
+        self,
+        earliest_order_id: str | None,
+        slot_since: datetime | None,
+    ) -> datetime | None:
+        """Return a current live ETA when it still belongs to this order."""
+        if (
+            earliest_order_id is None
+            or self._last_live_order_id != earliest_order_id
+            or self._last_live_value is None
+        ):
+            return None
+
+        if slot_since != self._last_live_slot_since:
+            self._clear_last_live_value()
+            return None
+
+        if dt_util.now() > self._last_live_value + LIVE_ETA_STALE_AFTER:
+            self._clear_last_live_value()
+            return None
+
+        return self._last_live_value
 
     @property
     def native_value(self) -> datetime | None:
@@ -184,6 +266,23 @@ class DeliveryTime(BaseEntity, SensorEntity, RestoreEntity):
             if earliest_order is not None and earliest_order.get("id") is not None
             else None
         )
+        slot_since = (
+            parse_delivery_datetime_string(
+                earliest_order.get("deliverySlot", {}).get("since")
+            )
+            if earliest_order is not None
+            else None
+        )
+
+        if (
+            self._last_live_order_id is not None
+            and self._last_live_order_id != earliest_order_id
+        ):
+            self._clear_last_live_value()
+
+        preserved_live_value = self._preserved_live_value(
+            earliest_order_id, slot_since
+        )
 
         if len(announcements) > 0:
             announcement = announcements[0]
@@ -200,48 +299,32 @@ class DeliveryTime(BaseEntity, SensorEntity, RestoreEntity):
                     self._last_value = delivery_time
                     self._last_live_value = delivery_time
                     self._last_live_order_id = earliest_order_id
+                    self._last_live_slot_since = slot_since
                     return delivery_time
 
-                if (
-                    earliest_order_id is not None
-                    and self._last_live_order_id == earliest_order_id
-                    and self._last_live_value is not None
-                ):
+                if preserved_live_value is not None:
                     # The announcement can remain present while no longer
                     # containing an ETA. Preserve the last precise value for
                     # this order instead of replacing it with the booked slot.
-                    self._last_value = self._last_live_value
-                    return self._last_live_value
+                    self._last_value = preserved_live_value
+                    return preserved_live_value
 
-            # An announcement for a different order must not allow an older
-            # live ETA to be resurrected after it later disappears.
-            self._clear_last_live_value(earliest_order_id)
+            elif preserved_live_value is not None:
+                # A later concurrent order's announcement does not supersede
+                # the last live ETA of the still-earliest order.
+                self._last_value = preserved_live_value
+                return preserved_live_value
 
-        elif (
-            earliest_order_id is not None
-            and self._last_live_order_id == earliest_order_id
-            and self._last_live_value is not None
-        ):
+        elif preserved_live_value is not None:
             # Rohlík commonly clears the announcement shortly before delivery.
             # Keep its precise ETA while the same order is still the soonest.
-            self._last_value = self._last_live_value
-            return self._last_live_value
-
-        if (
-            earliest_order_id is not None
-            and self._last_live_order_id is not None
-            and self._last_live_order_id != earliest_order_id
-        ):
-            self._clear_last_live_value()
+            self._last_value = preserved_live_value
+            return preserved_live_value
 
         # Fall back to the delivery slot of the soonest order.
-        if earliest_order is not None:
-            slot_since = parse_delivery_datetime_string(
-                earliest_order.get("deliverySlot", {}).get("since")
-            )
-            if slot_since is not None:
-                self._last_value = slot_since
-                return slot_since
+        if slot_since is not None:
+            self._last_value = slot_since
+            return slot_since
 
         # No live data available - preserve the last known value while an order
         # still exists so it isn't cleared shortly before delivery.
@@ -255,6 +338,15 @@ class DeliveryTime(BaseEntity, SensorEntity, RestoreEntity):
     @property
     def icon(self) -> str:
         return ICON_DELIVERY_TIME
+
+    @property
+    def extra_restore_state_data(self) -> DeliveryTimeExtraStoredData:
+        """Return delivery time data to restore after a restart."""
+        return DeliveryTimeExtraStoredData(
+            self._last_live_value,
+            self._last_live_order_id,
+            self._last_live_slot_since,
+        )
 
     async def async_added_to_hass(self) -> None:
         """Restore state when added to HA."""
@@ -275,6 +367,15 @@ class DeliveryTime(BaseEntity, SensorEntity, RestoreEntity):
                         "Failed to restore delivery time from last state %r",
                         last_state.state,
                     )
+
+        if (last_extra_data := await self.async_get_last_extra_data()) is not None:
+            restored = DeliveryTimeExtraStoredData.from_dict(
+                last_extra_data.as_dict()
+            )
+            if restored is not None:
+                self._last_live_value = restored.last_live_value
+                self._last_live_order_id = restored.last_live_order_id
+                self._last_live_slot_since = restored.last_live_slot_since
 
 
 @dataclass(frozen=True, kw_only=True)

--- a/tests/test_delivery_time.py
+++ b/tests/test_delivery_time.py
@@ -153,10 +153,10 @@ async def test_preserves_live_eta_when_same_announcement_loses_time(
     assert _state_time(hass, entity_id) == live_time
 
 
-async def test_concurrent_order_announcement_keeps_slot_fallback(
+async def test_concurrent_order_announcement_preserves_earliest_live_eta(
     hass: HomeAssistant,
 ) -> None:
-    """An announcement for a later order does not restore an older live ETA."""
+    """A later order's announcement does not erase the earliest live ETA."""
     live_time, slot_start = _delivery_times()
     data = sample_api_data()
     data["next_order"] = [_order(7001, slot_start)]
@@ -178,11 +178,88 @@ async def test_concurrent_order_announcement_keeps_slot_fallback(
     entry.runtime_data.async_set_updated_data(updated_data)
     await hass.async_block_till_done()
 
-    assert _state_time(hass, entity_id) == slot_start
+    assert _state_time(hass, entity_id) == live_time
 
     cleared_data = copy.deepcopy(updated_data)
     cleared_data["delivery_announcements"]["data"]["announcements"] = []
     entry.runtime_data.async_set_updated_data(cleared_data)
     await hass.async_block_till_done()
 
+    assert _state_time(hass, entity_id) == live_time
+
+
+async def test_changed_slot_invalidates_preserved_live_eta(
+    hass: HomeAssistant,
+) -> None:
+    """A rescheduled slot for the same order invalidates its old live ETA."""
+    live_time, slot_start = _delivery_times()
+    data = sample_api_data()
+    data["next_order"] = [_order(7001, slot_start)]
+    data["delivery_announcements"]["data"]["announcements"] = [
+        _announcement(7001, live_time)
+    ]
+
+    entry, entity_id = await _setup_delivery_time(hass, data)
+
+    changed_slot_start = slot_start + timedelta(hours=6)
+    updated_data = copy.deepcopy(data)
+    updated_data["next_order"] = [_order(7001, changed_slot_start)]
+    updated_data["delivery_announcements"]["data"]["announcements"] = []
+    entry.runtime_data.async_set_updated_data(updated_data)
+    await hass.async_block_till_done()
+
+    assert _state_time(hass, entity_id) == changed_slot_start
+
+
+async def test_stale_live_eta_falls_back_to_slot(
+    hass: HomeAssistant,
+) -> None:
+    """A live ETA is not preserved more than one hour after it passes."""
+    live_time, slot_start = _delivery_times()
+    data = sample_api_data()
+    data["next_order"] = [_order(7001, slot_start)]
+    data["delivery_announcements"]["data"]["announcements"] = [
+        _announcement(7001, live_time)
+    ]
+
+    entry, entity_id = await _setup_delivery_time(hass, data)
+
+    updated_data = copy.deepcopy(data)
+    updated_data["delivery_announcements"]["data"]["announcements"] = []
+    with patch(
+        "custom_components.rohlikcz.sensor.dt_util.now",
+        return_value=live_time + timedelta(hours=1, seconds=1),
+    ):
+        entry.runtime_data.async_set_updated_data(updated_data)
+        await hass.async_block_till_done()
+
     assert _state_time(hass, entity_id) == slot_start
+
+
+async def test_preserved_live_eta_survives_reload(
+    hass: HomeAssistant,
+) -> None:
+    """Live ETA metadata is restored when the entry reloads after clearing."""
+    live_time, slot_start = _delivery_times()
+    data = sample_api_data()
+    data["next_order"] = [_order(7001, slot_start)]
+    data["delivery_announcements"]["data"]["announcements"] = [
+        _announcement(7001, live_time)
+    ]
+
+    entry, entity_id = await _setup_delivery_time(hass, data)
+
+    cleared_data = copy.deepcopy(data)
+    cleared_data["delivery_announcements"]["data"]["announcements"] = []
+    entry.runtime_data.async_set_updated_data(cleared_data)
+    await hass.async_block_till_done()
+    assert _state_time(hass, entity_id) == live_time
+
+    with patch(
+        "custom_components.rohlikcz.hub.RohlikAPI.get_data",
+        new=AsyncMock(return_value=cleared_data),
+    ):
+        assert await hass.config_entries.async_reload(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert _state_time(hass, entity_id) == live_time

--- a/tests/test_delivery_time.py
+++ b/tests/test_delivery_time.py
@@ -1,0 +1,188 @@
+"""Tests for Delivery Time source selection and live ETA preservation."""
+from __future__ import annotations
+
+import copy
+from datetime import datetime, timedelta
+from unittest.mock import AsyncMock, patch
+from zoneinfo import ZoneInfo
+
+from homeassistant.const import CONF_EMAIL, CONF_PASSWORD
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+from homeassistant.util import dt as dt_util
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.rohlikcz.const import DOMAIN
+
+from fixtures_data import sample_api_data
+
+ENTRY_DATA = {CONF_EMAIL: "test@example.com", CONF_PASSWORD: "secret"}
+
+
+def _entry() -> MockConfigEntry:
+    return MockConfigEntry(
+        domain=DOMAIN, unique_id="123456", data=ENTRY_DATA, options={}
+    )
+
+
+def _order(order_id: int, slot_start: datetime) -> dict:
+    return {
+        "id": order_id,
+        "deliverySlot": {
+            "since": slot_start.isoformat(),
+            "till": (slot_start + timedelta(hours=1)).isoformat(),
+        },
+    }
+
+
+def _announcement(order_id: int, delivery_time: datetime) -> dict:
+    return {
+        "id": order_id,
+        "title": "Delivery",
+        "updatedAt": datetime.now(ZoneInfo("Europe/Prague")).isoformat(),
+        "content": (
+            'Doručíme v <span style="color:#009B37">'
+            f"{delivery_time:%H:%M}</span>"
+        ),
+    }
+
+
+async def _setup_delivery_time(
+    hass: HomeAssistant, data: dict
+) -> tuple[MockConfigEntry, str]:
+    entry = _entry()
+    entry.add_to_hass(hass)
+    with patch(
+        "custom_components.rohlikcz.hub.RohlikAPI.get_data",
+        new=AsyncMock(return_value=data),
+    ):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    entity_registry = er.async_get(hass)
+    entity_id = entity_registry.async_get_entity_id(
+        "sensor", DOMAIN, "123456_delivery_time"
+    )
+    assert entity_id is not None
+    return entry, entity_id
+
+
+def _delivery_times() -> tuple[datetime, datetime]:
+    now = datetime.now(ZoneInfo("Europe/Prague"))
+    live_time = now.replace(second=0, microsecond=0) + timedelta(minutes=30)
+    slot_start = live_time + timedelta(hours=2)
+    return live_time, slot_start
+
+
+def _state_time(hass: HomeAssistant, entity_id: str) -> datetime | None:
+    state = hass.states.get(entity_id)
+    assert state is not None
+    return dt_util.parse_datetime(state.state)
+
+
+async def test_preserves_live_eta_when_announcement_clears(
+    hass: HomeAssistant,
+) -> None:
+    """A cleared announcement keeps the live ETA for the same active order."""
+    live_time, slot_start = _delivery_times()
+    data = sample_api_data()
+    data["next_order"] = [_order(7001, slot_start)]
+    data["delivery_announcements"]["data"]["announcements"] = [
+        _announcement(7001, live_time)
+    ]
+
+    entry, entity_id = await _setup_delivery_time(hass, data)
+    assert _state_time(hass, entity_id) == live_time
+
+    updated_data = copy.deepcopy(data)
+    updated_data["delivery_announcements"]["data"]["announcements"] = []
+    entry.runtime_data.async_set_updated_data(updated_data)
+    await hass.async_block_till_done()
+
+    assert _state_time(hass, entity_id) == live_time
+
+
+async def test_does_not_carry_live_eta_to_next_order(
+    hass: HomeAssistant,
+) -> None:
+    """A new earliest order uses its slot instead of another order's live ETA."""
+    live_time, slot_start = _delivery_times()
+    data = sample_api_data()
+    data["next_order"] = [_order(7001, slot_start)]
+    data["delivery_announcements"]["data"]["announcements"] = [
+        _announcement(7001, live_time)
+    ]
+
+    entry, entity_id = await _setup_delivery_time(hass, data)
+
+    next_slot_start = slot_start + timedelta(days=1)
+    updated_data = copy.deepcopy(data)
+    updated_data["next_order"] = [_order(7002, next_slot_start)]
+    updated_data["delivery_announcements"]["data"]["announcements"] = []
+    entry.runtime_data.async_set_updated_data(updated_data)
+    await hass.async_block_till_done()
+
+    assert _state_time(hass, entity_id) == next_slot_start
+
+
+async def test_preserves_live_eta_when_same_announcement_loses_time(
+    hass: HomeAssistant,
+) -> None:
+    """A matching announcement without a time keeps that order's live ETA."""
+    live_time, slot_start = _delivery_times()
+    data = sample_api_data()
+    data["next_order"] = [_order(7001, slot_start)]
+    data["delivery_announcements"]["data"]["announcements"] = [
+        _announcement(7001, live_time)
+    ]
+
+    entry, entity_id = await _setup_delivery_time(hass, data)
+
+    updated_data = copy.deepcopy(data)
+    updated_data["delivery_announcements"]["data"]["announcements"] = [
+        {
+            "id": 7001,
+            "title": "Delivery",
+            "updatedAt": datetime.now(ZoneInfo("Europe/Prague")).isoformat(),
+            "content": "Kurýr je u vás.",
+        }
+    ]
+    entry.runtime_data.async_set_updated_data(updated_data)
+    await hass.async_block_till_done()
+
+    assert _state_time(hass, entity_id) == live_time
+
+
+async def test_concurrent_order_announcement_keeps_slot_fallback(
+    hass: HomeAssistant,
+) -> None:
+    """An announcement for a later order does not restore an older live ETA."""
+    live_time, slot_start = _delivery_times()
+    data = sample_api_data()
+    data["next_order"] = [_order(7001, slot_start)]
+    data["delivery_announcements"]["data"]["announcements"] = [
+        _announcement(7001, live_time)
+    ]
+
+    entry, entity_id = await _setup_delivery_time(hass, data)
+
+    later_slot_start = slot_start + timedelta(days=1)
+    updated_data = copy.deepcopy(data)
+    updated_data["next_order"] = [
+        _order(7001, slot_start),
+        _order(7002, later_slot_start),
+    ]
+    updated_data["delivery_announcements"]["data"]["announcements"] = [
+        _announcement(7002, later_slot_start)
+    ]
+    entry.runtime_data.async_set_updated_data(updated_data)
+    await hass.async_block_till_done()
+
+    assert _state_time(hass, entity_id) == slot_start
+
+    cleared_data = copy.deepcopy(updated_data)
+    cleared_data["delivery_announcements"]["data"]["announcements"] = []
+    entry.runtime_data.async_set_updated_data(cleared_data)
+    await hass.async_block_till_done()
+
+    assert _state_time(hass, entity_id) == slot_start


### PR DESCRIPTION
## Summary

- preserve the last parsed live ETA when the delivery announcement disappears for the same earliest active order
- also preserve it when the matching announcement remains present but no longer contains a parsable ETA
- keep the booked-slot fallback when the earliest order changes or the announcement belongs to a later concurrent order
- leave all v1.0.0-beta1 functionality, including `rohlikcz.update_delivery_times`, unchanged

## Why

The v1.0.0-beta1 API-package migration does not change the source-selection logic in `DeliveryTime`. It still falls back to `earliest_order.deliverySlot.since` before the existing last-value branch can run. We observed this shortly before real deliveries when Rohlik cleared the announcement while the order remained active.

The same-order behavior in this patch has also been observed successfully across three real deliveries on Home Assistant. The tests additionally protect the order-change and concurrent-order cases so a live ETA is not carried to the wrong order.

## Tests

- `python -m pytest tests/ -q` — 27 passed

Fixes #80.